### PR TITLE
pg_query Parser Patches for Postgres 13.1

### DIFF
--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -154,7 +154,8 @@ ExecLimit(PlanState *pstate)
 				if (!node->noCount &&
 					node->position - node->offset >= node->count)
 				{
-					if (node->limitOption == LIMIT_OPTION_COUNT)
+					if (node->limitOption == LIMIT_OPTION_COUNT ||
+						node->limitOption == LIMIT_OPTION_DEFAULT)
 					{
 						node->lstate = LIMIT_WINDOWEND;
 						return NULL;

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -620,6 +620,7 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 %token <ival>	ICONST PARAM
 %token			TYPECAST DOT_DOT COLON_EQUALS EQUALS_GREATER
 %token			LESS_EQUALS GREATER_EQUALS NOT_EQUALS
+%token			SQL_COMMENT C_COMMENT
 
 /*
  * If you want to make any keyword changes, update the keyword table in

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -162,6 +162,8 @@ static Node *makeBitStringConst(char *str, int location);
 static Node *makeNullAConst(int location);
 static Node *makeAConst(Value *v, int location);
 static Node *makeBoolAConst(bool state, int location);
+static Node *makeParamRef(int number, int location);
+static Node *makeParamRefCast(int number, int location, TypeName *typename);
 static RoleSpec *makeRoleSpec(RoleSpecType type, int location);
 static void check_qualified_name(List *names, core_yyscan_t yyscanner);
 static List *check_func_name(List *names, core_yyscan_t yyscanner);
@@ -1026,6 +1028,11 @@ AlterOptRoleElem:
 					$$ = makeDefElem("password",
 									 (Node *)makeString($2), @1);
 				}
+			| PASSWORD PARAM
+				{
+					$$ = makeDefElem("password",
+						(Node *)makeParamRef($2, @2), @1);
+				}
 			| PASSWORD NULL_P
 				{
 					$$ = makeDefElem("password", NULL, @1);
@@ -1039,6 +1046,16 @@ AlterOptRoleElem:
 					 */
 					$$ = makeDefElem("password",
 									 (Node *)makeString($3), @1);
+				}
+			| ENCRYPTED PASSWORD PARAM
+				{
+					/*
+					 * These days, passwords are always stored in encrypted
+					 * form, so there is no difference between PASSWORD and
+					 * ENCRYPTED PASSWORD.
+					 */
+					$$ = makeDefElem("password",
+									 (Node *)makeParamRef($3, @3), @1);
 				}
 			| UNENCRYPTED PASSWORD Sconst
 				{
@@ -1527,6 +1544,14 @@ set_rest_more:	/* Generic SET syntaxes: */
 					n->args = list_make1(makeStringConst($2, @2));
 					$$ = n;
 				}
+			| SCHEMA PARAM
+				{
+					VariableSetStmt *n = makeNode(VariableSetStmt);
+					n->kind = VAR_SET_VALUE;
+					n->name = "search_path";
+					n->args = list_make1(makeParamRef($2, @2));
+					$$ = n;
+				}
 			| NAMES opt_encoding
 				{
 					VariableSetStmt *n = makeNode(VariableSetStmt);
@@ -1546,12 +1571,28 @@ set_rest_more:	/* Generic SET syntaxes: */
 					n->args = list_make1(makeStringConst($2, @2));
 					$$ = n;
 				}
+			| ROLE PARAM
+				{
+					VariableSetStmt *n = makeNode(VariableSetStmt);
+					n->kind = VAR_SET_VALUE;
+					n->name = "role";
+					n->args = list_make1(makeParamRef($2, @2));
+					$$ = n;
+				}
 			| SESSION AUTHORIZATION NonReservedWord_or_Sconst
 				{
 					VariableSetStmt *n = makeNode(VariableSetStmt);
 					n->kind = VAR_SET_VALUE;
 					n->name = "session_authorization";
 					n->args = list_make1(makeStringConst($3, @3));
+					$$ = n;
+				}
+			| SESSION AUTHORIZATION PARAM
+				{
+					VariableSetStmt *n = makeNode(VariableSetStmt);
+					n->kind = VAR_SET_VALUE;
+					n->name = "session_authorization";
+					n->args = list_make1(makeParamRef($3, @3));
 					$$ = n;
 				}
 			| SESSION AUTHORIZATION DEFAULT
@@ -1593,6 +1634,8 @@ var_value:	opt_boolean_or_string
 				{ $$ = makeStringConst($1, @1); }
 			| NumericOnly
 				{ $$ = makeAConst($1, @1); }
+			| PARAM
+				{ $$ = makeParamRef($1, @1); }
 		;
 
 iso_level:	READ UNCOMMITTED						{ $$ = "read uncommitted"; }
@@ -1625,6 +1668,10 @@ zone_value:
 			Sconst
 				{
 					$$ = makeStringConst($1, @1);
+				}
+			| PARAM
+				{
+					$$ = makeParamRef($1, @1);
 				}
 			| IDENT
 				{
@@ -14648,6 +14695,10 @@ extract_list:
 				{
 					$$ = list_make2(makeStringConst($1, @1), $3);
 				}
+			| PARAM FROM a_expr
+				{
+					$$ = list_make2(makeParamRef($1, @1), $3);
+				}
 			| /*EMPTY*/								{ $$ = NIL; }
 		;
 
@@ -15092,6 +15143,45 @@ AexprConst: Iconst
 					t->location = @1;
 					$$ = makeStringConstCast($6, @6, t);
 				}
+			| func_name PARAM
+				{
+					/* generic type 'literal' syntax */
+					TypeName *t = makeTypeNameFromNameList($1);
+					t->location = @1;
+					$$ = makeParamRefCast($2, @2, t);
+				}
+			| func_name '(' func_arg_list opt_sort_clause ')' PARAM
+				{
+					/* generic syntax with a type modifier */
+					TypeName *t = makeTypeNameFromNameList($1);
+					ListCell *lc;
+
+					/*
+					 * We must use func_arg_list and opt_sort_clause in the
+					 * production to avoid reduce/reduce conflicts, but we
+					 * don't actually wish to allow NamedArgExpr in this
+					 * context, nor ORDER BY.
+					 */
+					foreach(lc, $3)
+					{
+						NamedArgExpr *arg = (NamedArgExpr *) lfirst(lc);
+
+						if (IsA(arg, NamedArgExpr))
+							ereport(ERROR,
+									(errcode(ERRCODE_SYNTAX_ERROR),
+									 errmsg("type modifier cannot have parameter name"),
+									 parser_errposition(arg->location)));
+					}
+					if ($4 != NIL)
+							ereport(ERROR,
+									(errcode(ERRCODE_SYNTAX_ERROR),
+									 errmsg("type modifier cannot have ORDER BY"),
+									 parser_errposition(@4)));
+
+					t->typmods = $3;
+					t->location = @1;
+					$$ = makeParamRefCast($6, @6, t);
+				}
 			| ConstTypename Sconst
 				{
 					$$ = makeStringConstCast($2, @2, $1);
@@ -15108,6 +15198,23 @@ AexprConst: Iconst
 					t->typmods = list_make2(makeIntConst(INTERVAL_FULL_RANGE, -1),
 											makeIntConst($3, @3));
 					$$ = makeStringConstCast($5, @5, t);
+				}
+			| ConstTypename PARAM
+				{
+					$$ = makeParamRefCast($2, @2, $1);
+				}
+			| ConstInterval PARAM opt_interval
+				{
+					TypeName *t = $1;
+					t->typmods = $3;
+					$$ = makeParamRefCast($2, @3, t);
+				}
+			| ConstInterval '(' Iconst ')' PARAM
+				{
+					TypeName *t = $1;
+					t->typmods = list_make2(makeIntConst(INTERVAL_FULL_RANGE, -1),
+											makeIntConst($3, @3));
+					$$ = makeParamRefCast($5, @5, t);
 				}
 			| TRUE_P
 				{
@@ -15961,6 +16068,24 @@ makeBoolAConst(bool state, int location)
 	n->location = location;
 
 	return makeTypeCast((Node *)n, SystemTypeName("bool"), -1);
+}
+
+/* makeParamRef
+ * Creates a new ParamRef node
+ */
+static Node* makeParamRef(int number, int location)
+{
+	ParamRef *p = makeNode(ParamRef);
+	p->number = number;
+	p->location = location;
+	return (Node *) p;
+}
+
+static Node *
+makeParamRefCast(int number, int location, TypeName *typename)
+{
+	Node *p = makeParamRef(number, location);
+	return makeTypeCast(p, typename, -1);
 }
 
 /* makeRoleSpec

--- a/src/backend/parser/parser.c
+++ b/src/backend/parser/parser.c
@@ -131,6 +131,9 @@ base_yylex(YYSTYPE *lvalp, YYLTYPE *llocp, core_yyscan_t yyscanner)
 		case USCONST:
 			cur_token_length = strlen(yyextra->core_yy_extra.scanbuf + *llocp);
 			break;
+		case SQL_COMMENT:
+		case C_COMMENT:
+			return base_yylex(lvalp, llocp, yyscanner);
 		default:
 			return cur_token;
 	}

--- a/src/backend/parser/scan.l
+++ b/src/backend/parser/scan.l
@@ -223,7 +223,7 @@ non_newline		[^\n\r]
 
 comment			("--"{non_newline}*)
 
-whitespace		({space}+|{comment})
+whitespace		({space}+)
 
 /*
  * SQL requires at least one newline in the whitespace separating
@@ -232,8 +232,8 @@ whitespace		({space}+|{comment})
  * it, whereas {whitespace} should generally have a * after it...
  */
 
-special_whitespace		({space}+|{comment}{newline})
-horiz_whitespace		({horiz_space}|{comment})
+special_whitespace		({space}+)
+horiz_whitespace		({horiz_space})
 whitespace_with_newline	({horiz_whitespace}*{newline}{special_whitespace}*)
 
 quote			'
@@ -423,6 +423,11 @@ other			.
 					/* ignore */
 				}
 
+{comment}	{
+					SET_YYLLOC();
+					return SQL_COMMENT;
+				}
+
 {xcstart}		{
 					/* Set location in case of syntax error in comment */
 					SET_YYLLOC();
@@ -441,7 +446,11 @@ other			.
 
 {xcstop}		{
 					if (yyextra->xcdepth <= 0)
+					{
 						BEGIN(INITIAL);
+						yyextra->yyllocend = yytext - yyextra->scanbuf + yyleng;
+						return C_COMMENT;
+					}
 					else
 						(yyextra->xcdepth)--;
 				}

--- a/src/backend/parser/scan.l
+++ b/src/backend/parser/scan.l
@@ -277,6 +277,9 @@ xehexesc		[\\]x[0-9A-Fa-f]{1,2}
 xeunicode		[\\](u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})
 xeunicodefail	[\\](u[0-9A-Fa-f]{0,3}|U[0-9A-Fa-f]{0,7})
 
+/* Normalized escaped string */
+xe_normalized  [eE]\?
+
 /* Extended quote
  * xqdouble implements embedded quote, ''''
  */
@@ -343,8 +346,9 @@ xcinside		[^*/]+
 digit			[0-9]
 ident_start		[A-Za-z\200-\377_]
 ident_cont		[A-Za-z\200-\377_0-9\$]
+ident_end     [\?]
 
-identifier		{ident_start}{ident_cont}*
+identifier		{ident_start}{ident_cont}*{ident_end}*
 
 /* Assorted special-case operators and operator-like tokens */
 typecast		"::"
@@ -375,7 +379,7 @@ not_equals		"!="
  * If you change either set, adjust the character lists appearing in the
  * rule for "operator"!
  */
-self			[,()\[\].;\:\+\-\*\/\%\^\<\>\=]
+self			[,()\[\].;\:\+\-\*\/\%\^\<\>\=\?]
 op_chars		[\~\!\@\#\^\&\|\`\?\+\-\*\/\%\<\>\=]
 operator		{op_chars}+
 
@@ -811,6 +815,11 @@ other			.
 					return IDENT;
 				}
 
+{xe_normalized} {
+					/* ignore E */
+					return yytext[1];
+				}
+
 {typecast}		{
 					SET_YYLLOC();
 					return TYPECAST;
@@ -917,6 +926,26 @@ other			.
 						}
 					}
 
+					/* We don't accept leading ? in any multi-character operators
+					 * except for those in use by hstore, JSON and geometric operators.
+					 *
+					 * We don't accept contained or trailing ? in any
+					 * multi-character operators, except for those in use by JSON operators.
+					 *
+					 * This is necessary in order to support normalized queries without
+					 * spacing between ? as a substition character and a simple operator (e.g. "?=?")
+					 */
+					if (yytext[0] == '?' &&
+					  strcmp(yytext, "?|") != 0 && strcmp(yytext, "?&") != 0 &&
+					  strcmp(yytext, "?#") != 0 && strcmp(yytext, "?-") != 0 &&
+					  strcmp(yytext, "?-|") != 0 && strcmp(yytext, "?||") != 0)
+						nchars = 1;
+
+					if (yytext[0] != '?' && strchr(yytext, '?') &&
+					  strcmp(yytext, "@?") != 0)
+						/* Lex up to just before the ? character */
+						nchars = strchr(yytext, '?') - yytext;
+
 					SET_YYLLOC();
 
 					if (nchars < yyleng)
@@ -930,7 +959,7 @@ other			.
 						 * that the "self" rule would have.
 						 */
 						if (nchars == 1 &&
-							strchr(",()[].;:+-*/%^<>=", yytext[0]))
+							strchr(",()[].;:+-*/%^<>=?", yytext[0]))
 							return yytext[0];
 						/*
 						 * Likewise, if what we have left is two chars, and
@@ -1012,14 +1041,19 @@ other			.
 {identifier}	{
 					int			kwnum;
 					char	   *ident;
+					char *keyword_text = pstrdup(yytext);
 
 					SET_YYLLOC();
 
 					/* Is it a keyword? */
-					kwnum = ScanKeywordLookup(yytext,
+					if (yytext[yyleng - 1] == '?')
+					  keyword_text[yyleng - 1] = '\0';
+					kwnum = ScanKeywordLookup(keyword_text,
 											  yyextra->keywordlist);
 					if (kwnum >= 0)
 					{
+						if (keyword_text[yyleng - 1] == '\0')
+						  yyless(yyleng - 1);
 						yylval->keyword = GetScanKeyword(kwnum,
 														 yyextra->keywordlist);
 						return yyextra->keyword_tokens[kwnum];

--- a/src/backend/parser/scan.l
+++ b/src/backend/parser/scan.l
@@ -517,6 +517,7 @@ other			.
 					{
 						/* If NCHAR isn't a keyword, just return "n" */
 						yylval->str = pstrdup("n");
+						yyextra->yyllocend = yytext - yyextra->scanbuf + yyleng;
 						return IDENT;
 					}
 				}
@@ -585,9 +586,11 @@ other			.
 					{
 						case xb:
 							yylval->str = litbufdup(yyscanner);
+							yyextra->yyllocend = yytext - yyextra->scanbuf + yyleng;
 							return BCONST;
 						case xh:
 							yylval->str = litbufdup(yyscanner);
+							yyextra->yyllocend = yytext - yyextra->scanbuf + yyleng;
 							return XCONST;
 						case xq:
 						case xe:
@@ -600,9 +603,11 @@ other			.
 											   yyextra->literallen,
 											   false);
 							yylval->str = litbufdup(yyscanner);
+							yyextra->yyllocend = yytext - yyextra->scanbuf + yyleng;
 							return SCONST;
 						case xus:
 							yylval->str = litbufdup(yyscanner);
+							yyextra->yyllocend = yytext - yyextra->scanbuf + yyleng;
 							return USCONST;
 						default:
 							yyerror("unhandled previous state in xqs");
@@ -740,6 +745,7 @@ other			.
 						yyextra->dolqstart = NULL;
 						BEGIN(INITIAL);
 						yylval->str = litbufdup(yyscanner);
+						yyextra->yyllocend = yytext - yyextra->scanbuf + yyleng;
 						return SCONST;
 					}
 					else
@@ -785,6 +791,7 @@ other			.
 					if (yyextra->literallen >= NAMEDATALEN)
 						truncate_identifier(ident, yyextra->literallen, true);
 					yylval->str = ident;
+					yyextra->yyllocend = yytext - yyextra->scanbuf + yyleng;
 					return IDENT;
 				}
 <xui>{dquote}	{
@@ -793,6 +800,7 @@ other			.
 						yyerror("zero-length delimited identifier");
 					/* can't truncate till after we de-escape the ident */
 					yylval->str = litbufdup(yyscanner);
+					yyextra->yyllocend = yytext - yyextra->scanbuf + yyleng;
 					return UIDENT;
 				}
 <xd,xui>{xddouble}	{
@@ -812,6 +820,7 @@ other			.
 					/* and treat it as {identifier} */
 					ident = downcase_truncate_identifier(yytext, yyleng, true);
 					yylval->str = ident;
+					yyextra->yyllocend = yytext - yyextra->scanbuf + yyleng;
 					return IDENT;
 				}
 
@@ -1065,6 +1074,7 @@ other			.
 					 */
 					ident = downcase_truncate_identifier(yytext, yyleng, true);
 					yylval->str = ident;
+					yyextra->yyllocend = yytext - yyextra->scanbuf + yyleng;
 					return IDENT;
 				}
 

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -834,9 +834,9 @@ typedef enum OnConflictAction
  */
 typedef enum LimitOption
 {
+	LIMIT_OPTION_DEFAULT,		/* No limit present */
 	LIMIT_OPTION_COUNT,			/* FETCH FIRST... ONLY */
 	LIMIT_OPTION_WITH_TIES,		/* FETCH FIRST... WITH TIES */
-	LIMIT_OPTION_DEFAULT,		/* No limit present */
 } LimitOption;
 
 #endif							/* NODES_H */

--- a/src/include/parser/scanner.h
+++ b/src/include/parser/scanner.h
@@ -113,6 +113,8 @@ typedef struct core_yy_extra_type
 	/* state variables for literal-lexing warnings */
 	bool		warn_on_first_escape;
 	bool		saw_non_ascii;
+
+	int yyllocend;
 } core_yy_extra_type;
 
 /*

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -155,6 +155,7 @@ extern MemoryContext AllocSetContextCreateInternal(MemoryContext parent,
 												   Size minContextSize,
 												   Size initBlockSize,
 												   Size maxBlockSize);
+extern void AllocSetDeleteFreeList(MemoryContext context);
 
 /*
  * This wrapper macro exists to check for non-constant strings used as context

--- a/src/interfaces/ecpg/preproc/parser.c
+++ b/src/interfaces/ecpg/preproc/parser.c
@@ -84,6 +84,9 @@ filtered_base_yylex(void)
 		case UIDENT:
 		case USCONST:
 			break;
+		case SQL_COMMENT:
+		case C_COMMENT:
+			return filtered_base_yylex();
 		default:
 			return cur_token;
 	}

--- a/src/pl/plpgsql/src/pl_comp.c
+++ b/src/pl/plpgsql/src/pl_comp.c
@@ -105,8 +105,6 @@ static Node *make_datum_param(PLpgSQL_expr *expr, int dno, int location);
 static PLpgSQL_row *build_row_from_vars(PLpgSQL_variable **vars, int numvars);
 static PLpgSQL_type *build_datatype(HeapTuple typeTup, int32 typmod,
 									Oid collation, TypeName *origtypname);
-static void plpgsql_start_datums(void);
-static void plpgsql_finish_datums(PLpgSQL_function *function);
 static void compute_function_hashkey(FunctionCallInfo fcinfo,
 									 Form_pg_proc procStruct,
 									 PLpgSQL_func_hashkey *hashkey,
@@ -2270,7 +2268,7 @@ plpgsql_parse_err_condition(char *condname)
  * plpgsql_start_datums			Initialize datum list at compile startup.
  * ----------
  */
-static void
+void
 plpgsql_start_datums(void)
 {
 	datums_alloc = 128;
@@ -2304,7 +2302,7 @@ plpgsql_adddatum(PLpgSQL_datum *newdatum)
  * plpgsql_finish_datums	Copy completed datum info into function struct.
  * ----------
  */
-static void
+void
 plpgsql_finish_datums(PLpgSQL_function *function)
 {
 	Size		copiable_size = 0;

--- a/src/pl/plpgsql/src/pl_gram.y
+++ b/src/pl/plpgsql/src/pl_gram.y
@@ -236,6 +236,7 @@ static	void			check_raise_parameters(PLpgSQL_stmt_raise *stmt);
 %token <ival>	ICONST PARAM
 %token			TYPECAST DOT_DOT COLON_EQUALS EQUALS_GREATER
 %token			LESS_EQUALS GREATER_EQUALS NOT_EQUALS
+%token			SQL_COMMENT C_COMMENT
 
 /*
  * Other tokens recognized by plpgsql's lexer interface layer (pl_scanner.c).

--- a/src/pl/plpgsql/src/pl_scanner.c
+++ b/src/pl/plpgsql/src/pl_scanner.c
@@ -342,6 +342,11 @@ internal_yylex(TokenAuxData *auxdata)
 		{
 			auxdata->lval.str = pstrdup(yytext);
 		}
+
+		else if (token == SQL_COMMENT || token == C_COMMENT)
+		{
+			token = internal_yylex(auxdata);
+		}
 	}
 
 	return token;

--- a/src/pl/plpgsql/src/plpgsql.h
+++ b/src/pl/plpgsql/src/plpgsql.h
@@ -1263,6 +1263,8 @@ extern PLpgSQL_recfield *plpgsql_build_recfield(PLpgSQL_rec *rec,
 extern int	plpgsql_recognize_err_condition(const char *condname,
 											bool allow_sqlstate);
 extern PLpgSQL_condition *plpgsql_parse_err_condition(char *condname);
+extern void plpgsql_start_datums(void);
+extern void plpgsql_finish_datums(PLpgSQL_function *function);
 extern void plpgsql_adddatum(PLpgSQL_datum *newdatum);
 extern int	plpgsql_add_initdatums(int **varnos);
 extern void plpgsql_HashTableInit(void);


### PR DESCRIPTION
Do not merge. This PR only exists to track the patches that are applied for pg_query (13-latest branch) on top of Postgres 13.1.