### PR TITLE
pg_query Parser Patches for Postgres 10.16

### DIFF
--- a/src/backend/parser/scan.l
+++ b/src/backend/parser/scan.l
@@ -253,6 +253,9 @@ xehexesc		[\\]x[0-9A-Fa-f]{1,2}
 xeunicode		[\\](u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})
 xeunicodefail	[\\](u[0-9A-Fa-f]{0,3}|U[0-9A-Fa-f]{0,7})
 
+/* Normalized escaped string */
+xe_normalized  [eE]\?
+
 /* Extended quote
  * xqdouble implements embedded quote, ''''
  */
@@ -328,8 +331,9 @@ xcinside		[^*/]+
 digit			[0-9]
 ident_start		[A-Za-z\200-\377_]
 ident_cont		[A-Za-z\200-\377_0-9\$]
+ident_end     [\?]
 
-identifier		{ident_start}{ident_cont}*
+identifier		{ident_start}{ident_cont}*{ident_end}*
 
 /* Assorted special-case operators and operator-like tokens */
 typecast		"::"
@@ -360,7 +364,7 @@ not_equals		"!="
  * If you change either set, adjust the character lists appearing in the
  * rule for "operator"!
  */
-self			[,()\[\].;\:\+\-\*\/\%\^\<\>\=]
+self			[,()\[\].;\:\+\-\*\/\%\^\<\>\=\?]
 op_chars		[\~\!\@\#\^\&\|\`\?\+\-\*\/\%\<\>\=]
 operator		{op_chars}+
 
@@ -813,6 +817,11 @@ other			.
 					return IDENT;
 				}
 
+{xe_normalized} {
+          /* ignore E */
+          return yytext[1];
+        }
+
 {typecast}		{
 					SET_YYLLOC();
 					return TYPECAST;
@@ -919,6 +928,25 @@ other			.
 						}
 					}
 
+          /* We don't accept leading ? in any multi-character operators
+           * except for those in use by hstore, JSON and geometric operators.
+           *
+           * We don't accept contained or trailing ? in any
+           * multi-character operators.
+           *
+           * This is necessary in order to support normalized queries without
+           * spacing between ? as a substition character and a simple operator (e.g. "?=?")
+           */
+          if (yytext[0] == '?' &&
+              strcmp(yytext, "?|") != 0 && strcmp(yytext, "?&") != 0 &&
+              strcmp(yytext, "?#") != 0 && strcmp(yytext, "?-") != 0 &&
+              strcmp(yytext, "?-|") != 0 && strcmp(yytext, "?||") != 0)
+            nchars = 1;
+
+          if (yytext[0] != '?' && strchr(yytext, '?'))
+            /* Lex up to just before the ? character */
+            nchars = strchr(yytext, '?') - yytext;
+
 					SET_YYLLOC();
 
 					if (nchars < yyleng)
@@ -932,7 +960,7 @@ other			.
 						 * that the "self" rule would have.
 						 */
 						if (nchars == 1 &&
-							strchr(",()[].;:+-*/%^<>=", yytext[0]))
+							strchr(",()[].;:+-*/%^<>=?", yytext[0]))
 							return yytext[0];
 						/*
 						 * Likewise, if what we have left is two chars, and
@@ -1018,15 +1046,21 @@ other			.
 {identifier}	{
 					const ScanKeyword *keyword;
 					char	   *ident;
+          char       *keyword_text = pstrdup(yytext);
 
 					SET_YYLLOC();
 
 					/* Is it a keyword? */
-					keyword = ScanKeywordLookup(yytext,
+          if (yytext[yyleng - 1] == '?')
+            keyword_text[yyleng - 1] = '\0';
+
+					keyword = ScanKeywordLookup(keyword_text,
 												yyextra->keywords,
 												yyextra->num_keywords);
 					if (keyword != NULL)
 					{
+            if (keyword_text[yyleng - 1] == '\0')
+              yyless(yyleng - 1);
 						yylval->keyword = keyword->name;
 						return keyword->value;
 					}

--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -216,7 +216,7 @@ static void AllocSetCheck(MemoryContext context);
 /*
  * This is the virtual function table for AllocSet contexts.
  */
-static MemoryContextMethods AllocSetMethods = {
+static const MemoryContextMethods AllocSetMethods = {
 	AllocSetAlloc,
 	AllocSetFree,
 	AllocSetRealloc,

--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -638,7 +638,7 @@ MemoryContextContains(MemoryContext context, void *pointer)
  */
 MemoryContext
 MemoryContextCreate(NodeTag tag, Size size,
-					MemoryContextMethods *methods,
+					const MemoryContextMethods *methods,
 					MemoryContext parent,
 					const char *name)
 {

--- a/src/backend/utils/mmgr/slab.c
+++ b/src/backend/utils/mmgr/slab.c
@@ -137,7 +137,7 @@ static void SlabCheck(MemoryContext context);
 /*
  * This is the virtual function table for Slab contexts.
  */
-static MemoryContextMethods SlabMethods = {
+static const MemoryContextMethods SlabMethods = {
 	SlabAlloc,
 	SlabFree,
 	SlabRealloc,

--- a/src/include/nodes/memnodes.h
+++ b/src/include/nodes/memnodes.h
@@ -76,7 +76,7 @@ typedef struct MemoryContextData
 	/* these two fields are placed here to minimize alignment wastage: */
 	bool		isReset;		/* T = no space alloced since last reset */
 	bool		allowInCritSection; /* allow palloc in critical section */
-	MemoryContextMethods *methods;	/* virtual function table */
+	const MemoryContextMethods *methods;	/* virtual function table */
 	MemoryContext parent;		/* NULL if no parent (toplevel context) */
 	MemoryContext firstchild;	/* head of linked list of children */
 	MemoryContext prevchild;	/* previous child of same parent */

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -133,7 +133,7 @@ GetMemoryChunkContext(void *pointer)
  * specific creation routines, and noplace else.
  */
 extern MemoryContext MemoryContextCreate(NodeTag tag, Size size,
-					MemoryContextMethods *methods,
+					const MemoryContextMethods *methods,
 					MemoryContext parent,
 					const char *name);
 

--- a/src/pl/plpgsql/src/pl_comp.c
+++ b/src/pl/plpgsql/src/pl_comp.c
@@ -107,8 +107,6 @@ static Node *make_datum_param(PLpgSQL_expr *expr, int dno, int location);
 static PLpgSQL_row *build_row_from_class(Oid classOid);
 static PLpgSQL_row *build_row_from_vars(PLpgSQL_variable **vars, int numvars);
 static PLpgSQL_type *build_datatype(HeapTuple typeTup, int32 typmod, Oid collation);
-static void plpgsql_start_datums(void);
-static void plpgsql_finish_datums(PLpgSQL_function *function);
 static void compute_function_hashkey(FunctionCallInfo fcinfo,
 						 Form_pg_proc procStruct,
 						 PLpgSQL_func_hashkey *hashkey,
@@ -2309,7 +2307,7 @@ plpgsql_parse_err_condition(char *condname)
  * plpgsql_start_datums			Initialize datum list at compile startup.
  * ----------
  */
-static void
+void
 plpgsql_start_datums(void)
 {
 	datums_alloc = 128;
@@ -2346,7 +2344,7 @@ plpgsql_adddatum(PLpgSQL_datum *new)
  * of the dnos of all ROW, REC, and RECFIELD datums in the function.
  * ----------
  */
-static void
+void
 plpgsql_finish_datums(PLpgSQL_function *function)
 {
 	Bitmapset  *resettable_datums = NULL;

--- a/src/pl/plpgsql/src/plpgsql.h
+++ b/src/pl/plpgsql/src/plpgsql.h
@@ -1078,6 +1078,8 @@ extern PLpgSQL_rec *plpgsql_build_record(const char *refname, int lineno,
 extern int plpgsql_recognize_err_condition(const char *condname,
 								bool allow_sqlstate);
 extern PLpgSQL_condition *plpgsql_parse_err_condition(char *condname);
+extern void plpgsql_start_datums(void);
+extern void plpgsql_finish_datums(PLpgSQL_function *function);
 extern void plpgsql_adddatum(PLpgSQL_datum *newdatum);
 extern int	plpgsql_add_initdatums(int **varnos);
 extern void plpgsql_HashTableInit(void);


### PR DESCRIPTION
Do not merge. This PR only exists to track the patches that are applied for pg_query (10-latest branch) on top of Postgres 10.16.