### PR TITLE
Optionally track I/O timing information in pg_stat_io

### DIFF
--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -1129,6 +1129,10 @@ SELECT
        b.evictions,
        b.reuses,
        b.fsyncs,
+       b.read_time,
+       b.write_time,
+       b.extend_time,
+       b.fsync_time,
        b.stats_reset
 FROM pg_stat_get_io() b;
 

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -57,6 +57,6 @@
  */
 
 /*							yyyymmddN */
-#define CATALOG_VERSION_NO	202302221
+#define CATALOG_VERSION_NO	202302261
 
 #endif

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -5721,9 +5721,9 @@
   proname => 'pg_stat_get_io', provolatile => 'v',
   prorows => '30', proretset => 't',
   proparallel => 'r', prorettype => 'record', proargtypes => '',
-  proallargtypes => '{text,text,text,int8,int8,int8,int8,int8,int8,int8,timestamptz}',
-  proargmodes => '{o,o,o,o,o,o,o,o,o,o,o}',
-  proargnames => '{backend_type,io_object,io_context,reads,writes,extends,op_bytes,evictions,reuses,fsyncs,stats_reset}',
+  proallargtypes => '{text,text,text,int8,int8,int8,int8,int8,int8,int8,float8,float8,float8,float8,timestamptz}',
+  proargmodes => '{o,o,o,o,o,o,o,o,o,o,o,o,o,o,o}',
+  proargnames => '{backend_type,io_object,io_context,reads,writes,extends,op_bytes,evictions,reuses,fsyncs,read_time,write_time,extend_time,fsync_time,stats_reset}',
   prosrc => 'pg_stat_get_io' },
 
 { oid => '1136', descr => 'statistics: information about WAL activity',

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -314,9 +314,21 @@ typedef enum IOOp
 #define IOOP_FIRST IOOP_EVICT
 #define IOOP_NUM_TYPES (IOOP_WRITE + 1)
 
+typedef enum IOOpTime
+{
+	IOOP_EXTEND_TIME,
+	IOOP_FSYNC_TIME,
+	IOOP_READ_TIME,
+	IOOP_WRITE_TIME,
+} IOOpTime;
+
+#define IOOP_TIME_FIRST IOOP_EXTEND_TIME
+#define IOOP_TIME_NUM_TYPES (IOOP_WRITE_TIME + 1)
+
 typedef struct PgStat_BktypeIO
 {
 	PgStat_Counter data[IOOBJECT_NUM_TYPES][IOCONTEXT_NUM_TYPES][IOOP_NUM_TYPES];
+	PgStat_Counter timings[IOOBJECT_NUM_TYPES][IOCONTEXT_NUM_TYPES][IOOP_TIME_NUM_TYPES];
 } PgStat_BktypeIO;
 
 typedef struct PgStat_IO
@@ -510,6 +522,7 @@ extern PgStat_CheckpointerStats *pgstat_fetch_stat_checkpointer(void);
 extern bool pgstat_bktype_io_stats_valid(PgStat_BktypeIO *context_ops,
 										 BackendType bktype);
 extern void pgstat_count_io_op(IOObject io_object, IOContext io_context, IOOp io_op);
+extern void pgstat_count_io_op_time(IOObject io_object, IOContext io_context, IOOpTime io_op_time, int64 time_us);
 extern PgStat_IO *pgstat_fetch_stat_io(void);
 extern const char *pgstat_get_io_context_name(IOContext io_context);
 extern const char *pgstat_get_io_object_name(IOObject io_object);
@@ -519,6 +532,8 @@ extern bool pgstat_tracks_io_object(BackendType bktype,
 									IOObject io_object, IOContext io_context);
 extern bool pgstat_tracks_io_op(BackendType bktype, IOObject io_object,
 								IOContext io_context, IOOp io_op);
+extern bool pgstat_tracks_io_op_time(BackendType bktype, IOObject io_object,
+									 IOContext io_context, IOOpTime io_op_time);
 
 
 /*

--- a/src/test/regress/expected/rules.out
+++ b/src/test/regress/expected/rules.out
@@ -1886,8 +1886,12 @@ pg_stat_io| SELECT backend_type,
     evictions,
     reuses,
     fsyncs,
+    read_time,
+    write_time,
+    extend_time,
+    fsync_time,
     stats_reset
-   FROM pg_stat_get_io() b(backend_type, io_object, io_context, reads, writes, extends, op_bytes, evictions, reuses, fsyncs, stats_reset);
+   FROM pg_stat_get_io() b(backend_type, io_object, io_context, reads, writes, extends, op_bytes, evictions, reuses, fsyncs, read_time, write_time, extend_time, fsync_time, stats_reset);
 pg_stat_progress_analyze| SELECT s.pid,
     s.datid,
     d.datname,


### PR DESCRIPTION
This repurposes the existing "track_io_timing" setting to also keep track of system-wide I/O timings, and reports read/write/extend/fsync time together with the I/O operation counts kept in pg_stat_io.

Beyond existing I/O timing that's already being collected, this adds new time measurements for file extends and fsyncs, as well as for writes to temporary relations.

---

TODO:

* [ ] Add docs
* [ ] Understand better why I/O timing doesn't match what's reported by EXPLAIN ANALYZE (are parallel workers the cause? and if so, is there a pre-existing bug around flushing of statistics when parallel workers shut down?)