### PR TITLE
pg_stat_statements_info: Add gc_count and query_file_size

### DIFF
--- a/contrib/pg_stat_statements/Makefile
+++ b/contrib/pg_stat_statements/Makefile
@@ -7,7 +7,8 @@ OBJS = \
 
 EXTENSION = pg_stat_statements
 DATA = pg_stat_statements--1.4.sql \
-	pg_stat_statements--1.11--1.12.sql pg_stat_statements--1.10--1.11.sql \
+	pg_stat_statements--1.12--1.13.sql \
+	pg_stat_statements--1.10--1.11.sql pg_stat_statements--1.11--1.12.sql \
 	pg_stat_statements--1.9--1.10.sql pg_stat_statements--1.8--1.9.sql \
 	pg_stat_statements--1.7--1.8.sql pg_stat_statements--1.6--1.7.sql \
 	pg_stat_statements--1.5--1.6.sql pg_stat_statements--1.4--1.5.sql \

--- a/contrib/pg_stat_statements/expected/oldextversions.out
+++ b/contrib/pg_stat_statements/expected/oldextversions.out
@@ -406,4 +406,17 @@ SELECT count(*) > 0 AS has_data FROM pg_stat_statements;
  t
 (1 row)
 
+-- New functions and views for pg_stat_statements_info in 1.13
+AlTER EXTENSION pg_stat_statements UPDATE TO '1.13';
+SELECT pg_get_functiondef('pg_stat_statements_info'::regproc);
+                                                                            pg_get_functiondef                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ CREATE OR REPLACE FUNCTION public.pg_stat_statements_info(OUT dealloc bigint, OUT gc_count bigint, OUT query_file_size bigint, OUT stats_reset timestamp with time zone)+
+  RETURNS record                                                                                                                                                         +
+  LANGUAGE c                                                                                                                                                             +
+  PARALLEL SAFE STRICT                                                                                                                                                   +
+ AS '$libdir/pg_stat_statements', $function$pg_stat_statements_info$function$                                                                                            +
+ 
+(1 row)
+
 DROP EXTENSION pg_stat_statements;

--- a/contrib/pg_stat_statements/meson.build
+++ b/contrib/pg_stat_statements/meson.build
@@ -23,6 +23,7 @@ install_data(
   'pg_stat_statements--1.4.sql',
   'pg_stat_statements--1.11--1.12.sql',
   'pg_stat_statements--1.10--1.11.sql',
+  'pg_stat_statements--1.12--1.13.sql',
   'pg_stat_statements--1.9--1.10.sql',
   'pg_stat_statements--1.8--1.9.sql',
   'pg_stat_statements--1.7--1.8.sql',

--- a/contrib/pg_stat_statements/pg_stat_statements--1.12--1.13.sql
+++ b/contrib/pg_stat_statements/pg_stat_statements--1.12--1.13.sql
@@ -1,0 +1,28 @@
+/* contrib/pg_stat_statements/pg_stat_statements--1.12--1.13.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_stat_statements UPDATE TO '1.13'" to load this file. \quit
+
+/* First we have to remove them from the extension */
+ALTER EXTENSION pg_stat_statements DROP VIEW pg_stat_statements_info;
+ALTER EXTENSION pg_stat_statements DROP FUNCTION pg_stat_statements_info();
+
+/* Then we can drop them */
+DROP VIEW pg_stat_statements_info;
+DROP FUNCTION pg_stat_statements_info();
+
+/* Now redefine */
+CREATE FUNCTION pg_stat_statements_info(
+    OUT dealloc bigint,
+    OUT gc_count bigint,
+    OUT query_file_size bigint,
+    OUT stats_reset timestamp with time zone
+)
+RETURNS record
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+
+CREATE VIEW pg_stat_statements_info AS
+  SELECT * FROM pg_stat_statements_info();
+
+GRANT SELECT ON pg_stat_statements_info TO PUBLIC;

--- a/contrib/pg_stat_statements/pg_stat_statements.c
+++ b/contrib/pg_stat_statements/pg_stat_statements.c
@@ -2002,7 +2002,7 @@ pg_stat_statements_internal(FunctionCallInfo fcinfo,
 }
 
 /* Number of output arguments (columns) for pg_stat_statements_info */
-#define PG_STAT_STATEMENTS_INFO_COLS	2
+#define PG_STAT_STATEMENTS_INFO_COLS	4
 
 /*
  * Return statistics of pg_stat_statements.
@@ -2014,6 +2014,7 @@ pg_stat_statements_info(PG_FUNCTION_ARGS)
 	TupleDesc	tupdesc;
 	Datum		values[PG_STAT_STATEMENTS_INFO_COLS] = {0};
 	bool		nulls[PG_STAT_STATEMENTS_INFO_COLS] = {0};
+	int64		gc_count, query_file_size;
 
 	if (!pgss || !pgss_hash)
 		ereport(ERROR,
@@ -2027,10 +2028,14 @@ pg_stat_statements_info(PG_FUNCTION_ARGS)
 	/* Read global statistics for pg_stat_statements */
 	SpinLockAcquire(&pgss->mutex);
 	stats = pgss->stats;
+	gc_count = pgss->gc_count;
+	query_file_size = pgss->extent;
 	SpinLockRelease(&pgss->mutex);
 
 	values[0] = Int64GetDatum(stats.dealloc);
-	values[1] = TimestampTzGetDatum(stats.stats_reset);
+	values[1] = Int64GetDatum(gc_count);
+	values[2] = Int64GetDatum(query_file_size);
+	values[3] = TimestampTzGetDatum(stats.stats_reset);
 
 	PG_RETURN_DATUM(HeapTupleGetDatum(heap_form_tuple(tupdesc, values, nulls)));
 }

--- a/contrib/pg_stat_statements/pg_stat_statements.control
+++ b/contrib/pg_stat_statements/pg_stat_statements.control
@@ -1,5 +1,5 @@
 # pg_stat_statements extension
 comment = 'track planning and execution statistics of all SQL statements executed'
-default_version = '1.12'
+default_version = '1.13'
 module_pathname = '$libdir/pg_stat_statements'
 relocatable = true

--- a/contrib/pg_stat_statements/sql/oldextversions.sql
+++ b/contrib/pg_stat_statements/sql/oldextversions.sql
@@ -63,4 +63,8 @@ AlTER EXTENSION pg_stat_statements UPDATE TO '1.12';
 \d pg_stat_statements
 SELECT count(*) > 0 AS has_data FROM pg_stat_statements;
 
+-- New functions and views for pg_stat_statements_info in 1.13
+AlTER EXTENSION pg_stat_statements UPDATE TO '1.13';
+SELECT pg_get_functiondef('pg_stat_statements_info'::regproc);
+
 DROP EXTENSION pg_stat_statements;

--- a/doc/src/sgml/pgstatstatements.sgml
+++ b/doc/src/sgml/pgstatstatements.sgml
@@ -754,6 +754,26 @@
      </row>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>gc_count</structfield> <type>bigint</type>
+      </para>
+      <para>
+       Total number of times the <structname>pg_stat_statements</structname> query text
+       file was rewritten for garbage collection (GC) purposes. This may occur after an
+       explicit call to <function>pg_stat_statements_reset</function>, or when sufficient
+       stale query texts have accumulated due to deallocations.
+      </para></entry>
+     </row>
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
+       <structfield>query_file_size</structfield> <type>bigint</type>
+      </para>
+      <para>
+       The cumulative size (in bytes) of all query texts stored in the
+       <structname>pg_stat_statements</structname> query text file.
+      </para></entry>
+     </row>
+     <row>
+      <entry role="catalog_table_entry"><para role="column_definition">
        <structfield>stats_reset</structfield> <type>timestamp with time zone</type>
       </para>
       <para>


### PR DESCRIPTION
This surfaces two internal fields from pg_stat_statements in the pg_stat_statements_info view to help with debugging.

"gc_count" helps understand when there are significant numbers of deallocations causing I/O overhead due to query text file rewrites.

"query_file_size" can be used to determine the query text file size without actually reading the file, e.g. for use in monitoring queries, or when deciding how often to get pg_stat_statements data with query texts.