### PR TITLE
Use stack for buffer/WAL usage instrumentation

### DIFF
--- a/contrib/pg_stat_statements/pg_stat_statements.c
+++ b/contrib/pg_stat_statements/pg_stat_statements.c
@@ -901,21 +901,11 @@ pgss_planner(Query *parse,
 		&& pgss_track_planning && query_string
 		&& parse->queryId != UINT64CONST(0))
 	{
+		InstrumentUsage *usage;
 		instr_time	start;
 		instr_time	duration;
-		BufferUsage bufusage_start,
-					bufusage;
-		WalUsage	walusage_start,
-					walusage;
 
-		/* We need to track buffer usage as the planner can access them. */
-		bufusage_start = pgBufferUsage;
-
-		/*
-		 * Similarly the planner could write some WAL records in some cases
-		 * (e.g. setting a hint bit with those being WAL-logged)
-		 */
-		walusage_start = pgWalUsage;
+		InstrUsageStart();
 		INSTR_TIME_SET_CURRENT(start);
 
 		nesting_level++;
@@ -936,14 +926,7 @@ pgss_planner(Query *parse,
 
 		INSTR_TIME_SET_CURRENT(duration);
 		INSTR_TIME_SUBTRACT(duration, start);
-
-		/* calc differences of buffer counters. */
-		memset(&bufusage, 0, sizeof(BufferUsage));
-		BufferUsageAccumDiff(&bufusage, &pgBufferUsage, &bufusage_start);
-
-		/* calc differences of WAL counters. */
-		memset(&walusage, 0, sizeof(WalUsage));
-		WalUsageAccumDiff(&walusage, &pgWalUsage, &walusage_start);
+		usage = InstrUsageStop();
 
 		pgss_store(query_string,
 				   parse->queryId,
@@ -952,8 +935,8 @@ pgss_planner(Query *parse,
 				   PGSS_PLAN,
 				   INSTR_TIME_GET_MILLISEC(duration),
 				   0,
-				   &bufusage,
-				   &walusage,
+				   &usage->bufusage,
+				   &usage->walusage,
 				   NULL,
 				   NULL,
 				   0,
@@ -1094,8 +1077,8 @@ pgss_ExecutorEnd(QueryDesc *queryDesc)
 				   PGSS_EXEC,
 				   queryDesc->totaltime->total * 1000.0,	/* convert to msec */
 				   queryDesc->estate->es_total_processed,
-				   &queryDesc->totaltime->bufusage,
-				   &queryDesc->totaltime->walusage,
+				   &queryDesc->totaltime->instrusage.bufusage,
+				   &queryDesc->totaltime->instrusage.walusage,
 				   queryDesc->estate->es_jit ? &queryDesc->estate->es_jit->instr : NULL,
 				   NULL,
 				   queryDesc->estate->es_parallel_workers_to_launch,
@@ -1158,16 +1141,12 @@ pgss_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 		!IsA(parsetree, ExecuteStmt) &&
 		!IsA(parsetree, PrepareStmt))
 	{
+		InstrumentUsage *usage;
 		instr_time	start;
 		instr_time	duration;
 		uint64		rows;
-		BufferUsage bufusage_start,
-					bufusage;
-		WalUsage	walusage_start,
-					walusage;
 
-		bufusage_start = pgBufferUsage;
-		walusage_start = pgWalUsage;
+		InstrUsageStart();
 		INSTR_TIME_SET_CURRENT(start);
 
 		nesting_level++;
@@ -1200,6 +1179,7 @@ pgss_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 
 		INSTR_TIME_SET_CURRENT(duration);
 		INSTR_TIME_SUBTRACT(duration, start);
+		usage = InstrUsageStop();
 
 		/*
 		 * Track the total number of rows retrieved or affected by the utility
@@ -1212,14 +1192,6 @@ pgss_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 					   qc->commandTag == CMDTAG_REFRESH_MATERIALIZED_VIEW)) ?
 			qc->nprocessed : 0;
 
-		/* calc differences of buffer counters. */
-		memset(&bufusage, 0, sizeof(BufferUsage));
-		BufferUsageAccumDiff(&bufusage, &pgBufferUsage, &bufusage_start);
-
-		/* calc differences of WAL counters. */
-		memset(&walusage, 0, sizeof(WalUsage));
-		WalUsageAccumDiff(&walusage, &pgWalUsage, &walusage_start);
-
 		pgss_store(queryString,
 				   saved_queryId,
 				   saved_stmt_location,
@@ -1227,8 +1199,8 @@ pgss_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 				   PGSS_EXEC,
 				   INSTR_TIME_GET_MILLISEC(duration),
 				   rows,
-				   &bufusage,
-				   &walusage,
+				   &usage->bufusage,
+				   &usage->walusage,
 				   NULL,
 				   NULL,
 				   0,

--- a/src/backend/access/brin/brin.c
+++ b/src/backend/access/brin/brin.c
@@ -47,8 +47,7 @@
 #define PARALLEL_KEY_BRIN_SHARED		UINT64CONST(0xB000000000000001)
 #define PARALLEL_KEY_TUPLESORT			UINT64CONST(0xB000000000000002)
 #define PARALLEL_KEY_QUERY_TEXT			UINT64CONST(0xB000000000000003)
-#define PARALLEL_KEY_WAL_USAGE			UINT64CONST(0xB000000000000004)
-#define PARALLEL_KEY_BUFFER_USAGE		UINT64CONST(0xB000000000000005)
+#define PARALLEL_KEY_INSTR_USAGE		UINT64CONST(0xB000000000000004)
 
 /*
  * Status for index builds performed in parallel.  This is allocated in a
@@ -144,8 +143,7 @@ typedef struct BrinLeader
 	BrinShared *brinshared;
 	Sharedsort *sharedsort;
 	Snapshot	snapshot;
-	WalUsage   *walusage;
-	BufferUsage *bufferusage;
+	InstrumentUsage *instrusage;
 } BrinLeader;
 
 /*
@@ -2371,8 +2369,7 @@ _brin_begin_parallel(BrinBuildState *buildstate, Relation heap, Relation index,
 	BrinShared *brinshared;
 	Sharedsort *sharedsort;
 	BrinLeader *brinleader = (BrinLeader *) palloc0(sizeof(BrinLeader));
-	WalUsage   *walusage;
-	BufferUsage *bufferusage;
+	InstrumentUsage *instrusage = NULL;
 	bool		leaderparticipates = true;
 	int			querylen;
 
@@ -2414,19 +2411,14 @@ _brin_begin_parallel(BrinBuildState *buildstate, Relation heap, Relation index,
 	shm_toc_estimate_keys(&pcxt->estimator, 2);
 
 	/*
-	 * Estimate space for WalUsage and BufferUsage -- PARALLEL_KEY_WAL_USAGE
-	 * and PARALLEL_KEY_BUFFER_USAGE.
-	 *
-	 * If there are no extensions loaded that care, we could skip this.  We
-	 * have no way of knowing whether anyone's looking at pgWalUsage or
-	 * pgBufferUsage, so do it unconditionally.
+	 * Estimate space for InstrUsage -- PARALLEL_KEY_INSTR_USAGE, if needed.
 	 */
-	shm_toc_estimate_chunk(&pcxt->estimator,
-						   mul_size(sizeof(WalUsage), pcxt->nworkers));
-	shm_toc_estimate_keys(&pcxt->estimator, 1);
-	shm_toc_estimate_chunk(&pcxt->estimator,
-						   mul_size(sizeof(BufferUsage), pcxt->nworkers));
-	shm_toc_estimate_keys(&pcxt->estimator, 1);
+	if (InstrumentUsageActive())
+	{
+		shm_toc_estimate_chunk(&pcxt->estimator,
+							   mul_size(sizeof(InstrumentUsage), pcxt->nworkers));
+		shm_toc_estimate_keys(&pcxt->estimator, 1);
+	}
 
 	/* Finally, estimate PARALLEL_KEY_QUERY_TEXT space */
 	if (debug_query_string)
@@ -2501,12 +2493,12 @@ _brin_begin_parallel(BrinBuildState *buildstate, Relation heap, Relation index,
 	 * Allocate space for each worker's WalUsage and BufferUsage; no need to
 	 * initialize.
 	 */
-	walusage = shm_toc_allocate(pcxt->toc,
-								mul_size(sizeof(WalUsage), pcxt->nworkers));
-	shm_toc_insert(pcxt->toc, PARALLEL_KEY_WAL_USAGE, walusage);
-	bufferusage = shm_toc_allocate(pcxt->toc,
-								   mul_size(sizeof(BufferUsage), pcxt->nworkers));
-	shm_toc_insert(pcxt->toc, PARALLEL_KEY_BUFFER_USAGE, bufferusage);
+	if (InstrumentUsageActive())
+	{
+		instrusage = shm_toc_allocate(pcxt->toc,
+									  mul_size(sizeof(InstrumentUsage), pcxt->nworkers));
+		shm_toc_insert(pcxt->toc, PARALLEL_KEY_INSTR_USAGE, instrusage);
+	}
 
 	/* Launch workers, saving status for leader/caller */
 	LaunchParallelWorkers(pcxt);
@@ -2517,8 +2509,7 @@ _brin_begin_parallel(BrinBuildState *buildstate, Relation heap, Relation index,
 	brinleader->brinshared = brinshared;
 	brinleader->sharedsort = sharedsort;
 	brinleader->snapshot = snapshot;
-	brinleader->walusage = walusage;
-	brinleader->bufferusage = bufferusage;
+	brinleader->instrusage = instrusage;
 
 	/* If no workers were successfully launched, back out (do serial build) */
 	if (pcxt->nworkers_launched == 0)
@@ -2553,11 +2544,14 @@ _brin_end_parallel(BrinLeader *brinleader, BrinBuildState *state)
 	WaitForParallelWorkersToFinish(brinleader->pcxt);
 
 	/*
-	 * Next, accumulate WAL usage.  (This must wait for the workers to finish,
-	 * or we might get incomplete data.)
+	 * Next, accumulate usage data.  (This must wait for the workers to
+	 * finish, or we might get incomplete data.)
 	 */
-	for (i = 0; i < brinleader->pcxt->nworkers_launched; i++)
-		InstrAccumParallelQuery(&brinleader->bufferusage[i], &brinleader->walusage[i]);
+	if (InstrumentUsageActive())
+	{
+		for (i = 0; i < brinleader->pcxt->nworkers_launched; i++)
+			InstrUsageAddToCurrent(&brinleader->instrusage[i]);
+	}
 
 	/* Free last reference to MVCC snapshot, if one was used */
 	if (IsMVCCSnapshot(brinleader->snapshot))
@@ -2870,8 +2864,7 @@ _brin_parallel_build_main(dsm_segment *seg, shm_toc *toc)
 	Relation	indexRel;
 	LOCKMODE	heapLockmode;
 	LOCKMODE	indexLockmode;
-	WalUsage   *walusage;
-	BufferUsage *bufferusage;
+	InstrumentUsage *shm_usage;
 	int			sortmem;
 
 	/*
@@ -2918,8 +2911,10 @@ _brin_parallel_build_main(dsm_segment *seg, shm_toc *toc)
 	sharedsort = shm_toc_lookup(toc, PARALLEL_KEY_TUPLESORT, false);
 	tuplesort_attach_shared(sharedsort, seg);
 
-	/* Prepare to track buffer usage during parallel execution */
-	InstrStartParallelQuery();
+	/* Prepare to track buffer usage during parallel execution, if needed */
+	shm_usage = shm_toc_lookup(toc, PARALLEL_KEY_INSTR_USAGE, true);
+	if (shm_usage)
+		InstrUsageStart();
 
 	/*
 	 * Might as well use reliable figure when doling out maintenance_work_mem
@@ -2932,10 +2927,12 @@ _brin_parallel_build_main(dsm_segment *seg, shm_toc *toc)
 								  heapRel, indexRel, sortmem, false);
 
 	/* Report WAL/buffer usage during parallel execution */
-	bufferusage = shm_toc_lookup(toc, PARALLEL_KEY_BUFFER_USAGE, false);
-	walusage = shm_toc_lookup(toc, PARALLEL_KEY_WAL_USAGE, false);
-	InstrEndParallelQuery(&bufferusage[ParallelWorkerNumber],
-						  &walusage[ParallelWorkerNumber]);
+	if (shm_usage)
+	{
+		InstrumentUsage *usage = InstrUsageStop();
+
+		memcpy(&shm_usage[ParallelWorkerNumber], usage, sizeof(InstrumentUsage));
+	}
 
 	index_close(indexRel, indexLockmode);
 	table_close(heapRel, heapLockmode);

--- a/src/backend/access/heap/vacuumlazy.c
+++ b/src/backend/access/heap/vacuumlazy.c
@@ -629,8 +629,6 @@ heap_vacuum_rel(Relation rel, VacuumParams *params,
 	TimestampTz starttime = 0;
 	PgStat_Counter startreadtime = 0,
 				startwritetime = 0;
-	WalUsage	startwalusage = pgWalUsage;
-	BufferUsage startbufferusage = pgBufferUsage;
 	ErrorContextCallback errcallback;
 	char	  **indnames = NULL;
 
@@ -639,6 +637,7 @@ heap_vacuum_rel(Relation rel, VacuumParams *params,
 							  params->log_min_duration >= 0));
 	if (instrument)
 	{
+		InstrUsageStart();
 		pg_rusage_init(&ru0);
 		if (track_io_timing)
 		{
@@ -945,6 +944,11 @@ heap_vacuum_rel(Relation rel, VacuumParams *params,
 	if (instrument)
 	{
 		TimestampTz endtime = GetCurrentTimestamp();
+		InstrumentUsage *usage;
+
+		/* support summary tracking of utility statements by extensions */
+		InstrUsageAccumToPrevious();
+		usage = InstrUsageStop();
 
 		if (verbose || params->log_min_duration == 0 ||
 			TimestampDifferenceExceeds(starttime, endtime,
@@ -952,8 +956,6 @@ heap_vacuum_rel(Relation rel, VacuumParams *params,
 		{
 			long		secs_dur;
 			int			usecs_dur;
-			WalUsage	walusage;
-			BufferUsage bufferusage;
 			StringInfoData buf;
 			char	   *msgfmt;
 			int32		diff;
@@ -964,17 +966,13 @@ heap_vacuum_rel(Relation rel, VacuumParams *params,
 			int64		total_blks_dirtied;
 
 			TimestampDifference(starttime, endtime, &secs_dur, &usecs_dur);
-			memset(&walusage, 0, sizeof(WalUsage));
-			WalUsageAccumDiff(&walusage, &pgWalUsage, &startwalusage);
-			memset(&bufferusage, 0, sizeof(BufferUsage));
-			BufferUsageAccumDiff(&bufferusage, &pgBufferUsage, &startbufferusage);
 
-			total_blks_hit = bufferusage.shared_blks_hit +
-				bufferusage.local_blks_hit;
-			total_blks_read = bufferusage.shared_blks_read +
-				bufferusage.local_blks_read;
-			total_blks_dirtied = bufferusage.shared_blks_dirtied +
-				bufferusage.local_blks_dirtied;
+			total_blks_hit = usage->bufusage.shared_blks_hit +
+				usage->bufusage.local_blks_hit;
+			total_blks_read = usage->bufusage.shared_blks_read +
+				usage->bufusage.local_blks_read;
+			total_blks_dirtied = usage->bufusage.shared_blks_dirtied +
+				usage->bufusage.local_blks_dirtied;
 
 			initStringInfo(&buf);
 			if (verbose)
@@ -1136,10 +1134,10 @@ heap_vacuum_rel(Relation rel, VacuumParams *params,
 							 total_blks_dirtied);
 			appendStringInfo(&buf,
 							 _("WAL usage: %" PRId64 " records, %" PRId64 " full page images, %" PRIu64 " bytes, %" PRId64 " buffers full\n"),
-							 walusage.wal_records,
-							 walusage.wal_fpi,
-							 walusage.wal_bytes,
-							 walusage.wal_buffers_full);
+							 usage->walusage.wal_records,
+							 usage->walusage.wal_fpi,
+							 usage->walusage.wal_bytes,
+							 usage->walusage.wal_buffers_full);
 			appendStringInfo(&buf, _("system usage: %s"), pg_rusage_show(&ru0));
 
 			ereport(verbose ? INFO : LOG,

--- a/src/backend/access/nbtree/nbtsort.c
+++ b/src/backend/access/nbtree/nbtsort.c
@@ -62,8 +62,7 @@
 #define PARALLEL_KEY_TUPLESORT			UINT64CONST(0xA000000000000002)
 #define PARALLEL_KEY_TUPLESORT_SPOOL2	UINT64CONST(0xA000000000000003)
 #define PARALLEL_KEY_QUERY_TEXT			UINT64CONST(0xA000000000000004)
-#define PARALLEL_KEY_WAL_USAGE			UINT64CONST(0xA000000000000005)
-#define PARALLEL_KEY_BUFFER_USAGE		UINT64CONST(0xA000000000000006)
+#define PARALLEL_KEY_INSTR_USAGE			UINT64CONST(0xA000000000000005)
 
 /*
  * DISABLE_LEADER_PARTICIPATION disables the leader's participation in
@@ -191,8 +190,7 @@ typedef struct BTLeader
 	Sharedsort *sharedsort;
 	Sharedsort *sharedsort2;
 	Snapshot	snapshot;
-	WalUsage   *walusage;
-	BufferUsage *bufferusage;
+	InstrumentUsage *instrusage;
 } BTLeader;
 
 /*
@@ -1406,8 +1404,7 @@ _bt_begin_parallel(BTBuildState *buildstate, bool isconcurrent, int request)
 	Sharedsort *sharedsort2;
 	BTSpool    *btspool = buildstate->spool;
 	BTLeader   *btleader = (BTLeader *) palloc0(sizeof(BTLeader));
-	WalUsage   *walusage;
-	BufferUsage *bufferusage;
+	InstrumentUsage *instrusage = NULL;
 	bool		leaderparticipates = true;
 	int			querylen;
 
@@ -1462,17 +1459,13 @@ _bt_begin_parallel(BTBuildState *buildstate, bool isconcurrent, int request)
 	/*
 	 * Estimate space for WalUsage and BufferUsage -- PARALLEL_KEY_WAL_USAGE
 	 * and PARALLEL_KEY_BUFFER_USAGE.
-	 *
-	 * If there are no extensions loaded that care, we could skip this.  We
-	 * have no way of knowing whether anyone's looking at pgWalUsage or
-	 * pgBufferUsage, so do it unconditionally.
 	 */
-	shm_toc_estimate_chunk(&pcxt->estimator,
-						   mul_size(sizeof(WalUsage), pcxt->nworkers));
-	shm_toc_estimate_keys(&pcxt->estimator, 1);
-	shm_toc_estimate_chunk(&pcxt->estimator,
-						   mul_size(sizeof(BufferUsage), pcxt->nworkers));
-	shm_toc_estimate_keys(&pcxt->estimator, 1);
+	if (InstrumentUsageActive())
+	{
+		shm_toc_estimate_chunk(&pcxt->estimator,
+							   mul_size(sizeof(InstrumentUsage), pcxt->nworkers));
+		shm_toc_estimate_keys(&pcxt->estimator, 1);
+	}
 
 	/* Finally, estimate PARALLEL_KEY_QUERY_TEXT space */
 	if (debug_query_string)
@@ -1561,12 +1554,12 @@ _bt_begin_parallel(BTBuildState *buildstate, bool isconcurrent, int request)
 	 * Allocate space for each worker's WalUsage and BufferUsage; no need to
 	 * initialize.
 	 */
-	walusage = shm_toc_allocate(pcxt->toc,
-								mul_size(sizeof(WalUsage), pcxt->nworkers));
-	shm_toc_insert(pcxt->toc, PARALLEL_KEY_WAL_USAGE, walusage);
-	bufferusage = shm_toc_allocate(pcxt->toc,
-								   mul_size(sizeof(BufferUsage), pcxt->nworkers));
-	shm_toc_insert(pcxt->toc, PARALLEL_KEY_BUFFER_USAGE, bufferusage);
+	if (InstrumentUsageActive())
+	{
+		instrusage = shm_toc_allocate(pcxt->toc,
+									  mul_size(sizeof(InstrumentUsage), pcxt->nworkers));
+		shm_toc_insert(pcxt->toc, PARALLEL_KEY_INSTR_USAGE, instrusage);
+	}
 
 	/* Launch workers, saving status for leader/caller */
 	LaunchParallelWorkers(pcxt);
@@ -1578,8 +1571,7 @@ _bt_begin_parallel(BTBuildState *buildstate, bool isconcurrent, int request)
 	btleader->sharedsort = sharedsort;
 	btleader->sharedsort2 = sharedsort2;
 	btleader->snapshot = snapshot;
-	btleader->walusage = walusage;
-	btleader->bufferusage = bufferusage;
+	btleader->instrusage = instrusage;
 
 	/* If no workers were successfully launched, back out (do serial build) */
 	if (pcxt->nworkers_launched == 0)
@@ -1617,8 +1609,11 @@ _bt_end_parallel(BTLeader *btleader)
 	 * Next, accumulate WAL usage.  (This must wait for the workers to finish,
 	 * or we might get incomplete data.)
 	 */
-	for (i = 0; i < btleader->pcxt->nworkers_launched; i++)
-		InstrAccumParallelQuery(&btleader->bufferusage[i], &btleader->walusage[i]);
+	if (InstrumentUsageActive())
+	{
+		for (i = 0; i < btleader->pcxt->nworkers_launched; i++)
+			InstrUsageAddToCurrent(&btleader->instrusage[i]);
+	}
 
 	/* Free last reference to MVCC snapshot, if one was used */
 	if (IsMVCCSnapshot(btleader->snapshot))
@@ -1751,8 +1746,7 @@ _bt_parallel_build_main(dsm_segment *seg, shm_toc *toc)
 	Relation	indexRel;
 	LOCKMODE	heapLockmode;
 	LOCKMODE	indexLockmode;
-	WalUsage   *walusage;
-	BufferUsage *bufferusage;
+	InstrumentUsage *shm_usage;
 	int			sortmem;
 
 #ifdef BTREE_BUILD_STATS
@@ -1825,8 +1819,10 @@ _bt_parallel_build_main(dsm_segment *seg, shm_toc *toc)
 		tuplesort_attach_shared(sharedsort2, seg);
 	}
 
-	/* Prepare to track buffer usage during parallel execution */
-	InstrStartParallelQuery();
+	/* Prepare to track buffer usage during parallel execution, if needed */
+	shm_usage = shm_toc_lookup(toc, PARALLEL_KEY_INSTR_USAGE, true);
+	if (shm_usage)
+		InstrUsageStart();
 
 	/* Perform sorting of spool, and possibly a spool2 */
 	sortmem = maintenance_work_mem / btshared->scantuplesortstates;
@@ -1834,10 +1830,12 @@ _bt_parallel_build_main(dsm_segment *seg, shm_toc *toc)
 							   sharedsort2, sortmem, false);
 
 	/* Report WAL/buffer usage during parallel execution */
-	bufferusage = shm_toc_lookup(toc, PARALLEL_KEY_BUFFER_USAGE, false);
-	walusage = shm_toc_lookup(toc, PARALLEL_KEY_WAL_USAGE, false);
-	InstrEndParallelQuery(&bufferusage[ParallelWorkerNumber],
-						  &walusage[ParallelWorkerNumber]);
+	if (shm_usage)
+	{
+		InstrumentUsage *usage = InstrUsageStop();
+
+		memcpy(&shm_usage[ParallelWorkerNumber], usage, sizeof(InstrumentUsage));
+	}
 
 #ifdef BTREE_BUILD_STATS
 	if (log_btree_build_stats)

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -1089,6 +1089,9 @@ XLogInsertRecord(XLogRecData *rdata,
 	/* Report WAL traffic to the instrumentation. */
 	if (inserted)
 	{
+		INSTR_WALUSAGE_ADD(wal_bytes, rechdr->xl_tot_len);
+		INSTR_WALUSAGE_INCR(wal_records);
+		INSTR_WALUSAGE_ADD(wal_fpi, num_fpi);
 		pgWalUsage.wal_bytes += rechdr->xl_tot_len;
 		pgWalUsage.wal_records++;
 		pgWalUsage.wal_fpi += num_fpi;

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -1993,6 +1993,7 @@ movedb(const char *dbname, const char *tblspcname)
 	DIR		   *dstdir;
 	struct dirent *xlde;
 	movedb_failure_params fparms;
+	InstrumentUsage *initial_usage = NULL;
 
 	/*
 	 * Look up the target database's OID, and get exclusive lock on it. We
@@ -2245,6 +2246,9 @@ movedb(const char *dbname, const char *tblspcname)
 	PG_END_ENSURE_ERROR_CLEANUP(movedb_failure_callback,
 								PointerGetDatum(&fparms));
 
+	if (InstrumentUsageActive())
+		initial_usage = InstrUsageStop();
+
 	/*
 	 * Commit the transaction so that the pg_database update is committed. If
 	 * we crash while removing files, the database won't be corrupt, we'll
@@ -2261,6 +2265,12 @@ movedb(const char *dbname, const char *tblspcname)
 
 	/* Start new transaction for the remaining work; don't need a snapshot */
 	StartTransactionCommand();
+
+	if (initial_usage != NULL)
+	{
+		InstrUsageStart();
+		InstrUsageAddToCurrent(initial_usage);
+	}
 
 	/*
 	 * Remove files from the old tablespace

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -4127,16 +4127,11 @@ show_buffer_usage(ExplainState *es, const BufferUsage *usage, hyperLogLogState *
 			{
 				appendStringInfoString(es->str, " shared");
 				if (usage->shared_blks_hit > 0)
-<<<<<<< HEAD
 					appendStringInfo(es->str, " hit=%" PRId64,
 									 usage->shared_blks_hit);
-=======
-					appendStringInfo(es->str, " hit=%lld",
-									 (long long) usage->shared_blks_hit);
 				if (shared_blks_hit_distinct)
 					appendStringInfo(es->str, " hit distinct=%lld",
 									 (long long) estimateHyperLogLog(shared_blks_hit_distinct));
->>>>>>> c226a30695a (WIP - add distinct)
 				if (usage->shared_blks_read > 0)
 					appendStringInfo(es->str, " read=%" PRId64,
 									 usage->shared_blks_read);

--- a/src/backend/commands/explain_state.c
+++ b/src/backend/commands/explain_state.c
@@ -95,7 +95,13 @@ ParseExplainOptionList(ExplainState *es, List *options, ParseState *pstate)
 		else if (strcmp(opt->defname, "buffers") == 0)
 		{
 			buffers_set = true;
-			es->buffers = defGetBoolean(opt);
+			if (opt->arg != NULL && strcmp(defGetString(opt), "distinct") == 0)
+			{
+				es->buffers = true;
+				es->buffers_distinct = true;
+			}
+			else
+				es->buffers = defGetBoolean(opt);
 		}
 		else if (strcmp(opt->defname, "wal") == 0)
 			es->wal = defGetBoolean(opt);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -400,7 +400,7 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 
 	/* Allow instrumentation of Executor overall runtime */
 	if (queryDesc->totaltime)
-		InstrStartNode(queryDesc->totaltime);
+		InstrStart(queryDesc->totaltime, true);
 
 	/*
 	 * extract information from the query descriptor and the query feature.
@@ -455,7 +455,7 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 	{
 		/* allow a potential calling EXPLAIN statement to capture the usage */
 		InstrUsageAccumToPrevious();
-		InstrStopNode(queryDesc->totaltime, estate->es_processed);
+		InstrStop(queryDesc->totaltime, estate->es_processed, true);
 	}
 
 	MemoryContextSwitchTo(oldcontext);
@@ -509,7 +509,7 @@ standard_ExecutorFinish(QueryDesc *queryDesc)
 
 	/* Allow instrumentation of Executor overall runtime */
 	if (queryDesc->totaltime)
-		InstrStartNode(queryDesc->totaltime);
+		InstrStart(queryDesc->totaltime, true);
 
 	/* Run ModifyTable nodes to completion */
 	ExecPostprocessPlan(estate);
@@ -522,7 +522,7 @@ standard_ExecutorFinish(QueryDesc *queryDesc)
 	{
 		/* allow a potential calling EXPLAIN statement to capture the usage */
 		InstrUsageAccumToPrevious();
-		InstrStopNode(queryDesc->totaltime, 0);
+		InstrStop(queryDesc->totaltime, 0, true);
 	}
 
 	MemoryContextSwitchTo(oldcontext);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -452,7 +452,11 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 		dest->rShutdown(dest);
 
 	if (queryDesc->totaltime)
+	{
+		/* allow a potential calling EXPLAIN statement to capture the usage */
+		InstrUsageAccumToPrevious();
 		InstrStopNode(queryDesc->totaltime, estate->es_processed);
+	}
 
 	MemoryContextSwitchTo(oldcontext);
 }
@@ -515,7 +519,11 @@ standard_ExecutorFinish(QueryDesc *queryDesc)
 		AfterTriggerEndQuery(estate);
 
 	if (queryDesc->totaltime)
+	{
+		/* allow a potential calling EXPLAIN statement to capture the usage */
+		InstrUsageAccumToPrevious();
 		InstrStopNode(queryDesc->totaltime, 0);
+	}
 
 	MemoryContextSwitchTo(oldcontext);
 

--- a/src/backend/executor/execParallel.c
+++ b/src/backend/executor/execParallel.c
@@ -58,13 +58,12 @@
 #define PARALLEL_KEY_EXECUTOR_FIXED		UINT64CONST(0xE000000000000001)
 #define PARALLEL_KEY_PLANNEDSTMT		UINT64CONST(0xE000000000000002)
 #define PARALLEL_KEY_PARAMLISTINFO		UINT64CONST(0xE000000000000003)
-#define PARALLEL_KEY_BUFFER_USAGE		UINT64CONST(0xE000000000000004)
+#define PARALLEL_KEY_INSTR_USAGE		UINT64CONST(0xE000000000000004)
 #define PARALLEL_KEY_TUPLE_QUEUE		UINT64CONST(0xE000000000000005)
 #define PARALLEL_KEY_INSTRUMENTATION	UINT64CONST(0xE000000000000006)
 #define PARALLEL_KEY_DSA				UINT64CONST(0xE000000000000007)
 #define PARALLEL_KEY_QUERY_TEXT		UINT64CONST(0xE000000000000008)
 #define PARALLEL_KEY_JIT_INSTRUMENTATION UINT64CONST(0xE000000000000009)
-#define PARALLEL_KEY_WAL_USAGE			UINT64CONST(0xE00000000000000A)
 
 #define PARALLEL_TUPLE_QUEUE_SIZE		65536
 
@@ -608,8 +607,6 @@ ExecInitParallelPlan(PlanState *planstate, EState *estate,
 	char	   *pstmt_data;
 	char	   *pstmt_space;
 	char	   *paramlistinfo_space;
-	BufferUsage *bufusage_space;
-	WalUsage   *walusage_space;
 	SharedExecutorInstrumentation *instrumentation = NULL;
 	SharedJitInstrumentation *jit_instrumentation = NULL;
 	int			pstmt_len;
@@ -673,22 +670,14 @@ ExecInitParallelPlan(PlanState *planstate, EState *estate,
 	shm_toc_estimate_keys(&pcxt->estimator, 1);
 
 	/*
-	 * Estimate space for BufferUsage.
-	 *
-	 * If EXPLAIN is not in use and there are no extensions loaded that care,
-	 * we could skip this.  But we have no way of knowing whether anyone's
-	 * looking at pgBufferUsage, so do it unconditionally.
+	 * Estimate space for InstrumentUsage, if needed.
 	 */
-	shm_toc_estimate_chunk(&pcxt->estimator,
-						   mul_size(sizeof(BufferUsage), pcxt->nworkers));
-	shm_toc_estimate_keys(&pcxt->estimator, 1);
-
-	/*
-	 * Same thing for WalUsage.
-	 */
-	shm_toc_estimate_chunk(&pcxt->estimator,
-						   mul_size(sizeof(WalUsage), pcxt->nworkers));
-	shm_toc_estimate_keys(&pcxt->estimator, 1);
+	if (InstrumentUsageActive())
+	{
+		shm_toc_estimate_chunk(&pcxt->estimator,
+							   mul_size(sizeof(InstrumentUsage), pcxt->nworkers));
+		shm_toc_estimate_keys(&pcxt->estimator, 1);
+	}
 
 	/* Estimate space for tuple queues. */
 	shm_toc_estimate_chunk(&pcxt->estimator,
@@ -773,17 +762,18 @@ ExecInitParallelPlan(PlanState *planstate, EState *estate,
 	shm_toc_insert(pcxt->toc, PARALLEL_KEY_PARAMLISTINFO, paramlistinfo_space);
 	SerializeParamList(estate->es_param_list_info, &paramlistinfo_space);
 
-	/* Allocate space for each worker's BufferUsage; no need to initialize. */
-	bufusage_space = shm_toc_allocate(pcxt->toc,
-									  mul_size(sizeof(BufferUsage), pcxt->nworkers));
-	shm_toc_insert(pcxt->toc, PARALLEL_KEY_BUFFER_USAGE, bufusage_space);
-	pei->buffer_usage = bufusage_space;
+	/*
+	 * Allocate space for each worker's InstrumentUsage; no need to
+	 * initialize.
+	 */
+	if (InstrumentUsageActive())
+	{
+		InstrumentUsage *instrusage = shm_toc_allocate(pcxt->toc,
+													   mul_size(sizeof(InstrumentUsage), pcxt->nworkers));
 
-	/* Same for WalUsage. */
-	walusage_space = shm_toc_allocate(pcxt->toc,
-									  mul_size(sizeof(WalUsage), pcxt->nworkers));
-	shm_toc_insert(pcxt->toc, PARALLEL_KEY_WAL_USAGE, walusage_space);
-	pei->wal_usage = walusage_space;
+		shm_toc_insert(pcxt->toc, PARALLEL_KEY_INSTR_USAGE, instrusage);
+		pei->instrusage = instrusage;
+	}
 
 	/* Set up the tuple queues that the workers will write into. */
 	pei->tqueue = ExecParallelSetupTupleQueues(pcxt, false);
@@ -1193,8 +1183,11 @@ ExecParallelFinish(ParallelExecutorInfo *pei)
 	 * Next, accumulate buffer/WAL usage.  (This must wait for the workers to
 	 * finish, or we might get incomplete data.)
 	 */
-	for (i = 0; i < nworkers; i++)
-		InstrAccumParallelQuery(&pei->buffer_usage[i], &pei->wal_usage[i]);
+	if (InstrumentUsageActive())
+	{
+		for (i = 0; i < nworkers; i++)
+			InstrUsageAddToCurrent(&pei->instrusage[i]);
+	}
 
 	pei->finished = true;
 }
@@ -1436,8 +1429,7 @@ void
 ParallelQueryMain(dsm_segment *seg, shm_toc *toc)
 {
 	FixedParallelExecutorState *fpes;
-	BufferUsage *buffer_usage;
-	WalUsage   *wal_usage;
+	InstrumentUsage *shm_usage;
 	DestReceiver *receiver;
 	QueryDesc  *queryDesc;
 	SharedExecutorInstrumentation *instrumentation;
@@ -1497,7 +1489,9 @@ ParallelQueryMain(dsm_segment *seg, shm_toc *toc)
 	 * leader, which also doesn't count buffer accesses and WAL activity that
 	 * occur during executor startup.
 	 */
-	InstrStartParallelQuery();
+	shm_usage = shm_toc_lookup(toc, PARALLEL_KEY_INSTR_USAGE, true);
+	if (shm_usage)
+		InstrUsageStart();
 
 	/*
 	 * Run the plan.  If we specified a tuple bound, be careful not to demand
@@ -1511,10 +1505,12 @@ ParallelQueryMain(dsm_segment *seg, shm_toc *toc)
 	ExecutorFinish(queryDesc);
 
 	/* Report buffer/WAL usage during parallel execution. */
-	buffer_usage = shm_toc_lookup(toc, PARALLEL_KEY_BUFFER_USAGE, false);
-	wal_usage = shm_toc_lookup(toc, PARALLEL_KEY_WAL_USAGE, false);
-	InstrEndParallelQuery(&buffer_usage[ParallelWorkerNumber],
-						  &wal_usage[ParallelWorkerNumber]);
+	if (shm_usage)
+	{
+		InstrumentUsage *usage = InstrUsageStop();
+
+		memcpy(&shm_usage[ParallelWorkerNumber], usage, sizeof(InstrumentUsage));
+	}
 
 	/* Report instrumentation data if any instrumentation options are set. */
 	if (instrumentation != NULL)

--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -302,7 +302,7 @@ ResOwnerReleaseInstrumentUsage(Datum res)
 void
 InstrUsageStart()
 {
-	InstrumentUsage *usage = palloc0(sizeof(InstrumentUsage));
+	InstrumentUsage *usage = MemoryContextAllocZero(TopMemoryContext, sizeof(InstrumentUsage));
 
 	PushInstrumentUsageWithOwner(usage);
 }

--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -204,14 +204,6 @@ InstrEndLoop(Instrumentation *instr)
 	instr->ntuples += instr->tuplecount;
 	instr->nloops += 1;
 
-	/*
-	 * Accumulate usage stats into active one (if any)
-	 *
-	 * This ensures that if we tracked buffer/WAL usage for EXPLAIN ANALYZE, a
-	 * potential extension interested in summary data can also get it.
-	 */
-	InstrUsageAddToCurrent(&instr->instrusage);
-
 	/* Reset for next cycle (if any) */
 	instr->running = false;
 	INSTR_TIME_SET_ZERO(instr->starttime);

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -1830,6 +1830,7 @@ opt_boolean_or_string:
 			TRUE_P									{ $$ = "true"; }
 			| FALSE_P								{ $$ = "false"; }
 			| ON									{ $$ = "on"; }
+			| DISTINCT								{ $$ = "distinct"; }
 			/*
 			 * OFF is also accepted as a boolean value, but is handled by
 			 * the NonReservedWord rule.  The action for booleans and strings

--- a/src/backend/storage/buffer/localbuf.c
+++ b/src/backend/storage/buffer/localbuf.c
@@ -216,7 +216,7 @@ FlushLocalBuffer(BufferDesc *bufHdr, SMgrRelation reln)
 	/* Mark not-dirty */
 	TerminateLocalBufferIO(bufHdr, true, 0, false);
 
-	pgBufferUsage.local_blks_written++;
+	INSTR_BUFUSAGE_INCR(local_blks_written);
 }
 
 static Buffer

--- a/src/backend/storage/buffer/localbuf.c
+++ b/src/backend/storage/buffer/localbuf.c
@@ -476,7 +476,7 @@ ExtendBufferedRelLocal(BufferManagerRelation bmr,
 
 	*extended_by = extend_by;
 
-	pgBufferUsage.local_blks_written += extend_by;
+	INSTR_BUFUSAGE_ADD(local_blks_written, extend_by);
 
 	return first_block;
 }
@@ -507,7 +507,7 @@ MarkLocalBufferDirty(Buffer buffer)
 	buf_state = pg_atomic_read_u32(&bufHdr->state);
 
 	if (!(buf_state & BM_DIRTY))
-		pgBufferUsage.local_blks_dirtied++;
+		INSTR_BUFUSAGE_INCR(local_blks_dirtied);
 
 	buf_state |= BM_DIRTY;
 

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -474,13 +474,13 @@ BufFileLoadBuffer(BufFile *file)
 	if (track_io_timing)
 	{
 		INSTR_TIME_SET_CURRENT(io_time);
-		INSTR_TIME_ACCUM_DIFF(pgBufferUsage.temp_blk_read_time, io_time, io_start);
+		INSTR_BUFUSAGE_TIME_ACCUM_DIFF(temp_blk_read_time, io_time, io_start);
 	}
 
 	/* we choose not to advance curOffset here */
 
 	if (file->nbytes > 0)
-		pgBufferUsage.temp_blks_read++;
+		INSTR_BUFUSAGE_INCR(temp_blks_read);
 }
 
 /*
@@ -548,13 +548,13 @@ BufFileDumpBuffer(BufFile *file)
 		if (track_io_timing)
 		{
 			INSTR_TIME_SET_CURRENT(io_time);
-			INSTR_TIME_ACCUM_DIFF(pgBufferUsage.temp_blk_write_time, io_time, io_start);
+			INSTR_BUFUSAGE_TIME_ACCUM_DIFF(temp_blk_write_time, io_time, io_start);
 		}
 
 		file->curOffset += bytestowrite;
 		wpos += bytestowrite;
 
-		pgBufferUsage.temp_blks_written++;
+		INSTR_BUFUSAGE_INCR(temp_blks_written);
 	}
 	file->dirty = false;
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4449,15 +4449,6 @@ PostgresMain(const char *dbname, const char *username)
 		debug_query_string = NULL;
 
 		/*
-		 * Reset the instrumentation usage stack, since we might have skipped
-		 * a InstrUsageStop call by jumping up. Note this should occur before
-		 * transaction abort since we might have a usage struct that was
-		 * allocated in a memory context that gets freed before abort logs WAL
-		 * usage.
-		 */
-		InstrUsageReset_AfterError();
-
-		/*
 		 * Abort the current transaction in order to recover.
 		 */
 		AbortCurrentTransaction();

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4449,6 +4449,15 @@ PostgresMain(const char *dbname, const char *username)
 		debug_query_string = NULL;
 
 		/*
+		 * Reset the instrumentation usage stack, since we might have skipped
+		 * a InstrUsageStop call by jumping up. Note this should occur before
+		 * transaction abort since we might have a usage struct that was
+		 * allocated in a memory context that gets freed before abort logs WAL
+		 * usage.
+		 */
+		InstrUsageReset_AfterError();
+
+		/*
 		 * Abort the current transaction in order to recover.
 		 */
 		AbortCurrentTransaction();

--- a/src/backend/utils/activity/pgstat_io.c
+++ b/src/backend/utils/activity/pgstat_io.c
@@ -134,17 +134,17 @@ pgstat_count_io_op_time(IOObject io_object, IOContext io_context, IOOp io_op,
 			{
 				pgstat_count_buffer_write_time(INSTR_TIME_GET_MICROSEC(io_time));
 				if (io_object == IOOBJECT_RELATION)
-					INSTR_TIME_ADD(pgBufferUsage.shared_blk_write_time, io_time);
+					INSTR_BUFUSAGE_TIME_ADD(shared_blk_write_time, io_time);
 				else if (io_object == IOOBJECT_TEMP_RELATION)
-					INSTR_TIME_ADD(pgBufferUsage.local_blk_write_time, io_time);
+					INSTR_BUFUSAGE_TIME_ADD(local_blk_write_time, io_time);
 			}
 			else if (io_op == IOOP_READ)
 			{
 				pgstat_count_buffer_read_time(INSTR_TIME_GET_MICROSEC(io_time));
 				if (io_object == IOOBJECT_RELATION)
-					INSTR_TIME_ADD(pgBufferUsage.shared_blk_read_time, io_time);
+					INSTR_BUFUSAGE_TIME_ADD(shared_blk_read_time, io_time);
 				else if (io_object == IOOBJECT_TEMP_RELATION)
-					INSTR_TIME_ADD(pgBufferUsage.local_blk_read_time, io_time);
+					INSTR_BUFUSAGE_TIME_ADD(local_blk_read_time, io_time);
 			}
 		}
 

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -156,7 +156,6 @@ extern PGDLLIMPORT bool XLOG_DEBUG;
 #define XLOG_INCLUDE_ORIGIN		0x01	/* include the replication origin */
 #define XLOG_MARK_UNIMPORTANT	0x02	/* record not important for durability */
 
-
 /* Checkpoint statistics */
 typedef struct CheckpointStatsData
 {

--- a/src/include/commands/explain_state.h
+++ b/src/include/commands/explain_state.h
@@ -49,6 +49,8 @@ typedef struct ExplainState
 	bool		analyze;		/* print actual times */
 	bool		costs;			/* print estimated costs */
 	bool		buffers;		/* print buffer usage */
+	bool		buffers_distinct;	/* print estimated distinct shared buffer
+									 * usage */
 	bool		wal;			/* print WAL usage */
 	bool		timing;			/* print detailed node timing */
 	bool		summary;		/* print total planning and execution timing */

--- a/src/include/executor/execParallel.h
+++ b/src/include/executor/execParallel.h
@@ -25,8 +25,7 @@ typedef struct ParallelExecutorInfo
 {
 	PlanState  *planstate;		/* plan subtree we're running in parallel */
 	ParallelContext *pcxt;		/* parallel context we're using */
-	BufferUsage *buffer_usage;	/* points to bufusage area in DSM */
-	WalUsage   *wal_usage;		/* walusage area in DSM */
+	InstrumentUsage *instrusage;	/* points to instrument usage area in DSM */
 	SharedExecutorInstrumentation *instrumentation; /* optional */
 	struct SharedJitInstrumentation *jit_instrumentation;	/* optional */
 	dsa_area   *area;			/* points to DSA area in DSM */

--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -155,11 +155,11 @@ InstrumentUsageActive(void)
 		INSTR_TIME_ACCUM_DIFF(pgInstrumentUsageStack->bufusage.fld, endval, startval); \
 	} while (0)
 
-#define INSTR_BUFUSAGE_COUNT_SHARED_HIT(bufHdr) do { \
+#define INSTR_BUFUSAGE_COUNT_SHARED_HIT(bufId) do { \
 		if (pgInstrumentUsageStack) { \
 			pgInstrumentUsageStack->bufusage.shared_blks_hit++; \
 			if (pgInstrumentUsageStack->shared_blks_hit_distinct) \
-				addHyperLogLog(pgInstrumentUsageStack->shared_blks_hit_distinct, DatumGetUInt32(hash_any((unsigned char *) &bufHdr->buf_id, sizeof(int)))); \
+				addHyperLogLog(pgInstrumentUsageStack->shared_blks_hit_distinct, DatumGetUInt32(hash_any((unsigned char *) &bufId, sizeof(int)))); \
 		} \
 	} while(0)
 

--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -13,14 +13,11 @@
 #ifndef INSTRUMENT_H
 #define INSTRUMENT_H
 
+#include "common/hashfn.h"
+#include "lib/hyperloglog.h"
 #include "portability/instr_time.h"
 
 
-/*
- * BufferUsage and WalUsage counters keep being incremented infinitely,
- * i.e., must never be reset to zero, so that we can calculate how much
- * the counters are incremented in an arbitrary period.
- */
 typedef struct BufferUsage
 {
 	int64		shared_blks_hit;	/* # of shared buffer hits */
@@ -63,8 +60,18 @@ typedef enum InstrumentOption
 	INSTRUMENT_BUFFERS = 1 << 1,	/* needs buffer usage */
 	INSTRUMENT_ROWS = 1 << 2,	/* needs row count */
 	INSTRUMENT_WAL = 1 << 3,	/* needs WAL usage */
+	INSTRUMENT_SHARED_HIT_DISTINCT = 1 << 4,	/* needs estimated distinct
+												 * shared hit buffer count */
 	INSTRUMENT_ALL = PG_INT32_MAX
 } InstrumentOption;
+
+typedef struct InstrumentUsage
+{
+	struct InstrumentUsage *previous;
+	BufferUsage bufusage;
+	WalUsage	walusage;
+	hyperLogLogState *shared_blks_hit_distinct;
+}			InstrumentUsage;
 
 typedef struct Instrumentation
 {
@@ -72,6 +79,9 @@ typedef struct Instrumentation
 	bool		need_timer;		/* true if we need timer data */
 	bool		need_bufusage;	/* true if we need buffer usage data */
 	bool		need_walusage;	/* true if we need WAL usage data */
+	bool		need_shared_hit_distinct;	/* true if we need estimated
+											 * distinct shared hit buffer
+											 * count */
 	bool		async_mode;		/* true if node is in async mode */
 	/* Info about current plan cycle: */
 	bool		running;		/* true if we've completed first tuple */
@@ -79,8 +89,6 @@ typedef struct Instrumentation
 	instr_time	counter;		/* accumulated runtime for this node */
 	double		firsttuple;		/* time for first tuple of this cycle */
 	double		tuplecount;		/* # of tuples emitted so far this cycle */
-	BufferUsage bufusage_start; /* buffer usage at start */
-	WalUsage	walusage_start; /* WAL usage at start */
 	/* Accumulated statistics across all completed cycles: */
 	double		startup;		/* total startup time (in seconds) */
 	double		total;			/* total time (in seconds) */
@@ -89,8 +97,7 @@ typedef struct Instrumentation
 	double		nloops;			/* # of run cycles for this node */
 	double		nfiltered1;		/* # of tuples removed by scanqual or joinqual */
 	double		nfiltered2;		/* # of tuples removed by "other" quals */
-	BufferUsage bufusage;		/* total buffer usage */
-	WalUsage	walusage;		/* total WAL usage */
+	InstrumentUsage instrusage; /* total buffer/WAL usage */
 } Instrumentation;
 
 typedef struct WorkerInstrumentation
@@ -99,8 +106,8 @@ typedef struct WorkerInstrumentation
 	Instrumentation instrument[FLEXIBLE_ARRAY_MEMBER];
 } WorkerInstrumentation;
 
-extern PGDLLIMPORT BufferUsage pgBufferUsage;
 extern PGDLLIMPORT WalUsage pgWalUsage;
+extern PGDLLIMPORT InstrumentUsage * pgInstrumentUsageStack;
 
 extern Instrumentation *InstrAlloc(int n, int instrument_options,
 								   bool async_mode);
@@ -110,12 +117,55 @@ extern void InstrStopNode(Instrumentation *instr, double nTuples);
 extern void InstrUpdateTupleCount(Instrumentation *instr, double nTuples);
 extern void InstrEndLoop(Instrumentation *instr);
 extern void InstrAggNode(Instrumentation *dst, Instrumentation *add);
-extern void InstrStartParallelQuery(void);
-extern void InstrEndParallelQuery(BufferUsage *bufusage, WalUsage *walusage);
-extern void InstrAccumParallelQuery(BufferUsage *bufusage, WalUsage *walusage);
-extern void BufferUsageAccumDiff(BufferUsage *dst,
-								 const BufferUsage *add, const BufferUsage *sub);
 extern void WalUsageAccumDiff(WalUsage *dst, const WalUsage *add,
 							  const WalUsage *sub);
+
+static inline bool
+InstrumentUsageActive(void)
+{
+	return pgInstrumentUsageStack != NULL;
+}
+
+#define INSTR_BUFUSAGE_INCR(fld) do { \
+		if (pgInstrumentUsageStack) \
+			pgInstrumentUsageStack->bufusage.fld++; \
+	} while(0)
+#define INSTR_BUFUSAGE_ADD(fld,val) do { \
+		if (pgInstrumentUsageStack) \
+			pgInstrumentUsageStack->bufusage.fld += val; \
+	} while(0)
+#define INSTR_BUFUSAGE_TIME_ADD(fld,val) do { \
+	if (pgInstrumentUsageStack) \
+		INSTR_TIME_ADD(pgInstrumentUsageStack->bufusage.fld, val); \
+	} while (0)
+#define INSTR_BUFUSAGE_TIME_ACCUM_DIFF(fld,endval,startval) do { \
+	if (pgInstrumentUsageStack) \
+		INSTR_TIME_ACCUM_DIFF(pgInstrumentUsageStack->bufusage.fld, endval, startval); \
+	} while (0)
+
+#define INSTR_BUFUSAGE_COUNT_SHARED_HIT(bufHdr) do { \
+		if (pgInstrumentUsageStack) { \
+			pgInstrumentUsageStack->bufusage.shared_blks_hit++; \
+			if (pgInstrumentUsageStack->shared_blks_hit_distinct) \
+				addHyperLogLog(pgInstrumentUsageStack->shared_blks_hit_distinct, DatumGetUInt32(hash_any((unsigned char *) &bufHdr->buf_id, sizeof(int)))); \
+		} \
+	} while(0)
+
+#define INSTR_WALUSAGE_INCR(fld) do { \
+		if (pgInstrumentUsageStack) \
+			pgInstrumentUsageStack->walusage.fld++; \
+	} while(0)
+#define INSTR_WALUSAGE_ADD(fld,val) do { \
+		if (pgInstrumentUsageStack) \
+			pgInstrumentUsageStack->walusage.fld += val; \
+	} while(0)
+
+extern void InstrUsageStart(void);
+extern InstrumentUsage * InstrUsageStop(void);
+extern void InstrUsageReset_AfterError(void);
+extern void InstrUsageAccumToPrevious(void);
+extern void InstrUsageAdd(InstrumentUsage * dst, const InstrumentUsage * add);
+extern void InstrUsageAddToCurrent(InstrumentUsage * instrusage);
+extern void BufferUsageAdd(BufferUsage *dst, const BufferUsage *add);
 
 #endif							/* INSTRUMENT_H */

--- a/src/test/regress/expected/explain.out
+++ b/src/test/regress/expected/explain.out
@@ -86,113 +86,111 @@ select explain_filter('explain (analyze, buffers, format text) select * from int
 (3 rows)
 
 select explain_filter('explain (analyze, buffers, format xml) select * from int8_tbl i8');
-                          explain_filter                          
-------------------------------------------------------------------
- <explain xmlns="http://www.postgresql.org/N/explain">           +
-   <Query>                                                       +
-     <Plan>                                                      +
-       <Node-Type>Seq Scan</Node-Type>                           +
-       <Parallel-Aware>false</Parallel-Aware>                    +
-       <Async-Capable>false</Async-Capable>                      +
-       <Relation-Name>int8_tbl</Relation-Name>                   +
-       <Alias>i8</Alias>                                         +
-       <Startup-Cost>N.N</Startup-Cost>                          +
-       <Total-Cost>N.N</Total-Cost>                              +
-       <Plan-Rows>N</Plan-Rows>                                  +
-       <Plan-Width>N</Plan-Width>                                +
-       <Actual-Startup-Time>N.N</Actual-Startup-Time>            +
-       <Actual-Total-Time>N.N</Actual-Total-Time>                +
-       <Actual-Rows>N.N</Actual-Rows>                            +
-       <Actual-Loops>N</Actual-Loops>                            +
-       <Disabled>false</Disabled>                                +
-       <Shared-Hit-Blocks>N</Shared-Hit-Blocks>                  +
-       <Shared-Hit-Distinct-Blocks>N</Shared-Hit-Distinct-Blocks>+
-       <Shared-Read-Blocks>N</Shared-Read-Blocks>                +
-       <Shared-Dirtied-Blocks>N</Shared-Dirtied-Blocks>          +
-       <Shared-Written-Blocks>N</Shared-Written-Blocks>          +
-       <Local-Hit-Blocks>N</Local-Hit-Blocks>                    +
-       <Local-Read-Blocks>N</Local-Read-Blocks>                  +
-       <Local-Dirtied-Blocks>N</Local-Dirtied-Blocks>            +
-       <Local-Written-Blocks>N</Local-Written-Blocks>            +
-       <Temp-Read-Blocks>N</Temp-Read-Blocks>                    +
-       <Temp-Written-Blocks>N</Temp-Written-Blocks>              +
-     </Plan>                                                     +
-     <Planning>                                                  +
-       <Shared-Hit-Blocks>N</Shared-Hit-Blocks>                  +
-       <Shared-Read-Blocks>N</Shared-Read-Blocks>                +
-       <Shared-Dirtied-Blocks>N</Shared-Dirtied-Blocks>          +
-       <Shared-Written-Blocks>N</Shared-Written-Blocks>          +
-       <Local-Hit-Blocks>N</Local-Hit-Blocks>                    +
-       <Local-Read-Blocks>N</Local-Read-Blocks>                  +
-       <Local-Dirtied-Blocks>N</Local-Dirtied-Blocks>            +
-       <Local-Written-Blocks>N</Local-Written-Blocks>            +
-       <Temp-Read-Blocks>N</Temp-Read-Blocks>                    +
-       <Temp-Written-Blocks>N</Temp-Written-Blocks>              +
-     </Planning>                                                 +
-     <Planning-Time>N.N</Planning-Time>                          +
-     <Triggers>                                                  +
-     </Triggers>                                                 +
-     <Execution-Time>N.N</Execution-Time>                        +
-   </Query>                                                      +
+                     explain_filter                     
+--------------------------------------------------------
+ <explain xmlns="http://www.postgresql.org/N/explain"> +
+   <Query>                                             +
+     <Plan>                                            +
+       <Node-Type>Seq Scan</Node-Type>                 +
+       <Parallel-Aware>false</Parallel-Aware>          +
+       <Async-Capable>false</Async-Capable>            +
+       <Relation-Name>int8_tbl</Relation-Name>         +
+       <Alias>i8</Alias>                               +
+       <Startup-Cost>N.N</Startup-Cost>                +
+       <Total-Cost>N.N</Total-Cost>                    +
+       <Plan-Rows>N</Plan-Rows>                        +
+       <Plan-Width>N</Plan-Width>                      +
+       <Actual-Startup-Time>N.N</Actual-Startup-Time>  +
+       <Actual-Total-Time>N.N</Actual-Total-Time>      +
+       <Actual-Rows>N.N</Actual-Rows>                  +
+       <Actual-Loops>N</Actual-Loops>                  +
+       <Disabled>false</Disabled>                      +
+       <Shared-Hit-Blocks>N</Shared-Hit-Blocks>        +
+       <Shared-Read-Blocks>N</Shared-Read-Blocks>      +
+       <Shared-Dirtied-Blocks>N</Shared-Dirtied-Blocks>+
+       <Shared-Written-Blocks>N</Shared-Written-Blocks>+
+       <Local-Hit-Blocks>N</Local-Hit-Blocks>          +
+       <Local-Read-Blocks>N</Local-Read-Blocks>        +
+       <Local-Dirtied-Blocks>N</Local-Dirtied-Blocks>  +
+       <Local-Written-Blocks>N</Local-Written-Blocks>  +
+       <Temp-Read-Blocks>N</Temp-Read-Blocks>          +
+       <Temp-Written-Blocks>N</Temp-Written-Blocks>    +
+     </Plan>                                           +
+     <Planning>                                        +
+       <Shared-Hit-Blocks>N</Shared-Hit-Blocks>        +
+       <Shared-Read-Blocks>N</Shared-Read-Blocks>      +
+       <Shared-Dirtied-Blocks>N</Shared-Dirtied-Blocks>+
+       <Shared-Written-Blocks>N</Shared-Written-Blocks>+
+       <Local-Hit-Blocks>N</Local-Hit-Blocks>          +
+       <Local-Read-Blocks>N</Local-Read-Blocks>        +
+       <Local-Dirtied-Blocks>N</Local-Dirtied-Blocks>  +
+       <Local-Written-Blocks>N</Local-Written-Blocks>  +
+       <Temp-Read-Blocks>N</Temp-Read-Blocks>          +
+       <Temp-Written-Blocks>N</Temp-Written-Blocks>    +
+     </Planning>                                       +
+     <Planning-Time>N.N</Planning-Time>                +
+     <Triggers>                                        +
+     </Triggers>                                       +
+     <Execution-Time>N.N</Execution-Time>              +
+   </Query>                                            +
  </explain>
 (1 row)
 
 select explain_filter('explain (analyze, serialize, buffers, format yaml) select * from int8_tbl i8');
-          explain_filter           
------------------------------------
- - Plan:                          +
-     Node Type: "Seq Scan"        +
-     Parallel Aware: false        +
-     Async Capable: false         +
-     Relation Name: "int8_tbl"    +
-     Alias: "i8"                  +
-     Startup Cost: N.N            +
-     Total Cost: N.N              +
-     Plan Rows: N                 +
-     Plan Width: N                +
-     Actual Startup Time: N.N     +
-     Actual Total Time: N.N       +
-     Actual Rows: N.N             +
-     Actual Loops: N              +
-     Disabled: false              +
-     Shared Hit Blocks: N         +
-     Shared Hit Distinct Blocks: N+
-     Shared Read Blocks: N        +
-     Shared Dirtied Blocks: N     +
-     Shared Written Blocks: N     +
-     Local Hit Blocks: N          +
-     Local Read Blocks: N         +
-     Local Dirtied Blocks: N      +
-     Local Written Blocks: N      +
-     Temp Read Blocks: N          +
-     Temp Written Blocks: N       +
-   Planning:                      +
-     Shared Hit Blocks: N         +
-     Shared Read Blocks: N        +
-     Shared Dirtied Blocks: N     +
-     Shared Written Blocks: N     +
-     Local Hit Blocks: N          +
-     Local Read Blocks: N         +
-     Local Dirtied Blocks: N      +
-     Local Written Blocks: N      +
-     Temp Read Blocks: N          +
-     Temp Written Blocks: N       +
-   Planning Time: N.N             +
-   Triggers:                      +
-   Serialization:                 +
-     Time: N.N                    +
-     Output Volume: N             +
-     Format: "text"               +
-     Shared Hit Blocks: N         +
-     Shared Read Blocks: N        +
-     Shared Dirtied Blocks: N     +
-     Shared Written Blocks: N     +
-     Local Hit Blocks: N          +
-     Local Read Blocks: N         +
-     Local Dirtied Blocks: N      +
-     Local Written Blocks: N      +
-     Temp Read Blocks: N          +
-     Temp Written Blocks: N       +
+        explain_filter         
+-------------------------------
+ - Plan:                      +
+     Node Type: "Seq Scan"    +
+     Parallel Aware: false    +
+     Async Capable: false     +
+     Relation Name: "int8_tbl"+
+     Alias: "i8"              +
+     Startup Cost: N.N        +
+     Total Cost: N.N          +
+     Plan Rows: N             +
+     Plan Width: N            +
+     Actual Startup Time: N.N +
+     Actual Total Time: N.N   +
+     Actual Rows: N.N         +
+     Actual Loops: N          +
+     Disabled: false          +
+     Shared Hit Blocks: N     +
+     Shared Read Blocks: N    +
+     Shared Dirtied Blocks: N +
+     Shared Written Blocks: N +
+     Local Hit Blocks: N      +
+     Local Read Blocks: N     +
+     Local Dirtied Blocks: N  +
+     Local Written Blocks: N  +
+     Temp Read Blocks: N      +
+     Temp Written Blocks: N   +
+   Planning:                  +
+     Shared Hit Blocks: N     +
+     Shared Read Blocks: N    +
+     Shared Dirtied Blocks: N +
+     Shared Written Blocks: N +
+     Local Hit Blocks: N      +
+     Local Read Blocks: N     +
+     Local Dirtied Blocks: N  +
+     Local Written Blocks: N  +
+     Temp Read Blocks: N      +
+     Temp Written Blocks: N   +
+   Planning Time: N.N         +
+   Triggers:                  +
+   Serialization:             +
+     Time: N.N                +
+     Output Volume: N         +
+     Format: "text"           +
+     Shared Hit Blocks: N     +
+     Shared Read Blocks: N    +
+     Shared Dirtied Blocks: N +
+     Shared Written Blocks: N +
+     Local Hit Blocks: N      +
+     Local Read Blocks: N     +
+     Local Dirtied Blocks: N  +
+     Local Written Blocks: N  +
+     Temp Read Blocks: N      +
+     Temp Written Blocks: N   +
    Execution Time: N.N
 (1 row)
 
@@ -285,66 +283,65 @@ select explain_filter('explain verbose select sum(unique1) over w1, sum(unique2)
 -- but always set in JSON format, so check them only in this case.
 set track_io_timing = on;
 select explain_filter('explain (analyze, buffers, format json) select * from int8_tbl i8');
-             explain_filter             
-----------------------------------------
- [                                     +
-   {                                   +
-     "Plan": {                         +
-       "Node Type": "Seq Scan",        +
-       "Parallel Aware": false,        +
-       "Async Capable": false,         +
-       "Relation Name": "int8_tbl",    +
-       "Alias": "i8",                  +
-       "Startup Cost": N.N,            +
-       "Total Cost": N.N,              +
-       "Plan Rows": N,                 +
-       "Plan Width": N,                +
-       "Actual Startup Time": N.N,     +
-       "Actual Total Time": N.N,       +
-       "Actual Rows": N.N,             +
-       "Actual Loops": N,              +
-       "Disabled": false,              +
-       "Shared Hit Blocks": N,         +
-       "Shared Hit Distinct Blocks": N,+
-       "Shared Read Blocks": N,        +
-       "Shared Dirtied Blocks": N,     +
-       "Shared Written Blocks": N,     +
-       "Local Hit Blocks": N,          +
-       "Local Read Blocks": N,         +
-       "Local Dirtied Blocks": N,      +
-       "Local Written Blocks": N,      +
-       "Temp Read Blocks": N,          +
-       "Temp Written Blocks": N,       +
-       "Shared I/O Read Time": N.N,    +
-       "Shared I/O Write Time": N.N,   +
-       "Local I/O Read Time": N.N,     +
-       "Local I/O Write Time": N.N,    +
-       "Temp I/O Read Time": N.N,      +
-       "Temp I/O Write Time": N.N      +
-     },                                +
-     "Planning": {                     +
-       "Shared Hit Blocks": N,         +
-       "Shared Read Blocks": N,        +
-       "Shared Dirtied Blocks": N,     +
-       "Shared Written Blocks": N,     +
-       "Local Hit Blocks": N,          +
-       "Local Read Blocks": N,         +
-       "Local Dirtied Blocks": N,      +
-       "Local Written Blocks": N,      +
-       "Temp Read Blocks": N,          +
-       "Temp Written Blocks": N,       +
-       "Shared I/O Read Time": N.N,    +
-       "Shared I/O Write Time": N.N,   +
-       "Local I/O Read Time": N.N,     +
-       "Local I/O Write Time": N.N,    +
-       "Temp I/O Read Time": N.N,      +
-       "Temp I/O Write Time": N.N      +
-     },                                +
-     "Planning Time": N.N,             +
-     "Triggers": [                     +
-     ],                                +
-     "Execution Time": N.N             +
-   }                                   +
+           explain_filter            
+-------------------------------------
+ [                                  +
+   {                                +
+     "Plan": {                      +
+       "Node Type": "Seq Scan",     +
+       "Parallel Aware": false,     +
+       "Async Capable": false,      +
+       "Relation Name": "int8_tbl", +
+       "Alias": "i8",               +
+       "Startup Cost": N.N,         +
+       "Total Cost": N.N,           +
+       "Plan Rows": N,              +
+       "Plan Width": N,             +
+       "Actual Startup Time": N.N,  +
+       "Actual Total Time": N.N,    +
+       "Actual Rows": N.N,          +
+       "Actual Loops": N,           +
+       "Disabled": false,           +
+       "Shared Hit Blocks": N,      +
+       "Shared Read Blocks": N,     +
+       "Shared Dirtied Blocks": N,  +
+       "Shared Written Blocks": N,  +
+       "Local Hit Blocks": N,       +
+       "Local Read Blocks": N,      +
+       "Local Dirtied Blocks": N,   +
+       "Local Written Blocks": N,   +
+       "Temp Read Blocks": N,       +
+       "Temp Written Blocks": N,    +
+       "Shared I/O Read Time": N.N, +
+       "Shared I/O Write Time": N.N,+
+       "Local I/O Read Time": N.N,  +
+       "Local I/O Write Time": N.N, +
+       "Temp I/O Read Time": N.N,   +
+       "Temp I/O Write Time": N.N   +
+     },                             +
+     "Planning": {                  +
+       "Shared Hit Blocks": N,      +
+       "Shared Read Blocks": N,     +
+       "Shared Dirtied Blocks": N,  +
+       "Shared Written Blocks": N,  +
+       "Local Hit Blocks": N,       +
+       "Local Read Blocks": N,      +
+       "Local Dirtied Blocks": N,   +
+       "Local Written Blocks": N,   +
+       "Temp Read Blocks": N,       +
+       "Temp Written Blocks": N,    +
+       "Shared I/O Read Time": N.N, +
+       "Shared I/O Write Time": N.N,+
+       "Local I/O Read Time": N.N,  +
+       "Local I/O Write Time": N.N, +
+       "Temp I/O Read Time": N.N,   +
+       "Temp I/O Write Time": N.N   +
+     },                             +
+     "Planning Time": N.N,          +
+     "Triggers": [                  +
+     ],                             +
+     "Execution Time": N.N          +
+   }                                +
  ]
 (1 row)
 
@@ -421,56 +418,55 @@ select explain_filter('explain (memory, summary, format yaml) select * from int8
 (1 row)
 
 select explain_filter('explain (memory, analyze, format json) select * from int8_tbl i8');
-             explain_filter             
-----------------------------------------
- [                                     +
-   {                                   +
-     "Plan": {                         +
-       "Node Type": "Seq Scan",        +
-       "Parallel Aware": false,        +
-       "Async Capable": false,         +
-       "Relation Name": "int8_tbl",    +
-       "Alias": "i8",                  +
-       "Startup Cost": N.N,            +
-       "Total Cost": N.N,              +
-       "Plan Rows": N,                 +
-       "Plan Width": N,                +
-       "Actual Startup Time": N.N,     +
-       "Actual Total Time": N.N,       +
-       "Actual Rows": N.N,             +
-       "Actual Loops": N,              +
-       "Disabled": false,              +
-       "Shared Hit Blocks": N,         +
-       "Shared Hit Distinct Blocks": N,+
-       "Shared Read Blocks": N,        +
-       "Shared Dirtied Blocks": N,     +
-       "Shared Written Blocks": N,     +
-       "Local Hit Blocks": N,          +
-       "Local Read Blocks": N,         +
-       "Local Dirtied Blocks": N,      +
-       "Local Written Blocks": N,      +
-       "Temp Read Blocks": N,          +
-       "Temp Written Blocks": N        +
-     },                                +
-     "Planning": {                     +
-       "Shared Hit Blocks": N,         +
-       "Shared Read Blocks": N,        +
-       "Shared Dirtied Blocks": N,     +
-       "Shared Written Blocks": N,     +
-       "Local Hit Blocks": N,          +
-       "Local Read Blocks": N,         +
-       "Local Dirtied Blocks": N,      +
-       "Local Written Blocks": N,      +
-       "Temp Read Blocks": N,          +
-       "Temp Written Blocks": N,       +
-       "Memory Used": N,               +
-       "Memory Allocated": N           +
-     },                                +
-     "Planning Time": N.N,             +
-     "Triggers": [                     +
-     ],                                +
-     "Execution Time": N.N             +
-   }                                   +
+           explain_filter           
+------------------------------------
+ [                                 +
+   {                               +
+     "Plan": {                     +
+       "Node Type": "Seq Scan",    +
+       "Parallel Aware": false,    +
+       "Async Capable": false,     +
+       "Relation Name": "int8_tbl",+
+       "Alias": "i8",              +
+       "Startup Cost": N.N,        +
+       "Total Cost": N.N,          +
+       "Plan Rows": N,             +
+       "Plan Width": N,            +
+       "Actual Startup Time": N.N, +
+       "Actual Total Time": N.N,   +
+       "Actual Rows": N.N,         +
+       "Actual Loops": N,          +
+       "Disabled": false,          +
+       "Shared Hit Blocks": N,     +
+       "Shared Read Blocks": N,    +
+       "Shared Dirtied Blocks": N, +
+       "Shared Written Blocks": N, +
+       "Local Hit Blocks": N,      +
+       "Local Read Blocks": N,     +
+       "Local Dirtied Blocks": N,  +
+       "Local Written Blocks": N,  +
+       "Temp Read Blocks": N,      +
+       "Temp Written Blocks": N    +
+     },                            +
+     "Planning": {                 +
+       "Shared Hit Blocks": N,     +
+       "Shared Read Blocks": N,    +
+       "Shared Dirtied Blocks": N, +
+       "Shared Written Blocks": N, +
+       "Local Hit Blocks": N,      +
+       "Local Read Blocks": N,     +
+       "Local Dirtied Blocks": N,  +
+       "Local Written Blocks": N,  +
+       "Temp Read Blocks": N,      +
+       "Temp Written Blocks": N,   +
+       "Memory Used": N,           +
+       "Memory Allocated": N       +
+     },                            +
+     "Planning Time": N.N,         +
+     "Triggers": [                 +
+     ],                            +
+     "Execution Time": N.N         +
+   }                               +
  ]
 (1 row)
 
@@ -586,8 +582,7 @@ select jsonb_pretty(
                              "Local Dirtied Blocks": 0,     +
                              "Local Written Blocks": 0,     +
                              "Shared Dirtied Blocks": 0,    +
-                             "Shared Written Blocks": 0,    +
-                             "Shared Hit Distinct Blocks": 0+
+                             "Shared Written Blocks": 0     +
                          }                                  +
                      ],                                     +
                      "Output": [                            +
@@ -634,8 +629,7 @@ select jsonb_pretty(
                      "Local Dirtied Blocks": 0,             +
                      "Local Written Blocks": 0,             +
                      "Shared Dirtied Blocks": 0,            +
-                     "Shared Written Blocks": 0,            +
-                     "Shared Hit Distinct Blocks": 0        +
+                     "Shared Written Blocks": 0             +
                  }                                          +
              ],                                             +
              "Output": [                                    +
@@ -679,8 +673,7 @@ select jsonb_pretty(
              "Local Dirtied Blocks": 0,                     +
              "Local Written Blocks": 0,                     +
              "Shared Dirtied Blocks": 0,                    +
-             "Shared Written Blocks": 0,                    +
-             "Shared Hit Distinct Blocks": 0                +
+             "Shared Written Blocks": 0                     +
          },                                                 +
          "Planning": {                                      +
              "Local Hit Blocks": 0,                         +

--- a/src/test/regress/expected/explain.out
+++ b/src/test/regress/expected/explain.out
@@ -86,111 +86,113 @@ select explain_filter('explain (analyze, buffers, format text) select * from int
 (3 rows)
 
 select explain_filter('explain (analyze, buffers, format xml) select * from int8_tbl i8');
-                     explain_filter                     
---------------------------------------------------------
- <explain xmlns="http://www.postgresql.org/N/explain"> +
-   <Query>                                             +
-     <Plan>                                            +
-       <Node-Type>Seq Scan</Node-Type>                 +
-       <Parallel-Aware>false</Parallel-Aware>          +
-       <Async-Capable>false</Async-Capable>            +
-       <Relation-Name>int8_tbl</Relation-Name>         +
-       <Alias>i8</Alias>                               +
-       <Startup-Cost>N.N</Startup-Cost>                +
-       <Total-Cost>N.N</Total-Cost>                    +
-       <Plan-Rows>N</Plan-Rows>                        +
-       <Plan-Width>N</Plan-Width>                      +
-       <Actual-Startup-Time>N.N</Actual-Startup-Time>  +
-       <Actual-Total-Time>N.N</Actual-Total-Time>      +
-       <Actual-Rows>N.N</Actual-Rows>                  +
-       <Actual-Loops>N</Actual-Loops>                  +
-       <Disabled>false</Disabled>                      +
-       <Shared-Hit-Blocks>N</Shared-Hit-Blocks>        +
-       <Shared-Read-Blocks>N</Shared-Read-Blocks>      +
-       <Shared-Dirtied-Blocks>N</Shared-Dirtied-Blocks>+
-       <Shared-Written-Blocks>N</Shared-Written-Blocks>+
-       <Local-Hit-Blocks>N</Local-Hit-Blocks>          +
-       <Local-Read-Blocks>N</Local-Read-Blocks>        +
-       <Local-Dirtied-Blocks>N</Local-Dirtied-Blocks>  +
-       <Local-Written-Blocks>N</Local-Written-Blocks>  +
-       <Temp-Read-Blocks>N</Temp-Read-Blocks>          +
-       <Temp-Written-Blocks>N</Temp-Written-Blocks>    +
-     </Plan>                                           +
-     <Planning>                                        +
-       <Shared-Hit-Blocks>N</Shared-Hit-Blocks>        +
-       <Shared-Read-Blocks>N</Shared-Read-Blocks>      +
-       <Shared-Dirtied-Blocks>N</Shared-Dirtied-Blocks>+
-       <Shared-Written-Blocks>N</Shared-Written-Blocks>+
-       <Local-Hit-Blocks>N</Local-Hit-Blocks>          +
-       <Local-Read-Blocks>N</Local-Read-Blocks>        +
-       <Local-Dirtied-Blocks>N</Local-Dirtied-Blocks>  +
-       <Local-Written-Blocks>N</Local-Written-Blocks>  +
-       <Temp-Read-Blocks>N</Temp-Read-Blocks>          +
-       <Temp-Written-Blocks>N</Temp-Written-Blocks>    +
-     </Planning>                                       +
-     <Planning-Time>N.N</Planning-Time>                +
-     <Triggers>                                        +
-     </Triggers>                                       +
-     <Execution-Time>N.N</Execution-Time>              +
-   </Query>                                            +
+                          explain_filter                          
+------------------------------------------------------------------
+ <explain xmlns="http://www.postgresql.org/N/explain">           +
+   <Query>                                                       +
+     <Plan>                                                      +
+       <Node-Type>Seq Scan</Node-Type>                           +
+       <Parallel-Aware>false</Parallel-Aware>                    +
+       <Async-Capable>false</Async-Capable>                      +
+       <Relation-Name>int8_tbl</Relation-Name>                   +
+       <Alias>i8</Alias>                                         +
+       <Startup-Cost>N.N</Startup-Cost>                          +
+       <Total-Cost>N.N</Total-Cost>                              +
+       <Plan-Rows>N</Plan-Rows>                                  +
+       <Plan-Width>N</Plan-Width>                                +
+       <Actual-Startup-Time>N.N</Actual-Startup-Time>            +
+       <Actual-Total-Time>N.N</Actual-Total-Time>                +
+       <Actual-Rows>N.N</Actual-Rows>                            +
+       <Actual-Loops>N</Actual-Loops>                            +
+       <Disabled>false</Disabled>                                +
+       <Shared-Hit-Blocks>N</Shared-Hit-Blocks>                  +
+       <Shared-Hit-Distinct-Blocks>N</Shared-Hit-Distinct-Blocks>+
+       <Shared-Read-Blocks>N</Shared-Read-Blocks>                +
+       <Shared-Dirtied-Blocks>N</Shared-Dirtied-Blocks>          +
+       <Shared-Written-Blocks>N</Shared-Written-Blocks>          +
+       <Local-Hit-Blocks>N</Local-Hit-Blocks>                    +
+       <Local-Read-Blocks>N</Local-Read-Blocks>                  +
+       <Local-Dirtied-Blocks>N</Local-Dirtied-Blocks>            +
+       <Local-Written-Blocks>N</Local-Written-Blocks>            +
+       <Temp-Read-Blocks>N</Temp-Read-Blocks>                    +
+       <Temp-Written-Blocks>N</Temp-Written-Blocks>              +
+     </Plan>                                                     +
+     <Planning>                                                  +
+       <Shared-Hit-Blocks>N</Shared-Hit-Blocks>                  +
+       <Shared-Read-Blocks>N</Shared-Read-Blocks>                +
+       <Shared-Dirtied-Blocks>N</Shared-Dirtied-Blocks>          +
+       <Shared-Written-Blocks>N</Shared-Written-Blocks>          +
+       <Local-Hit-Blocks>N</Local-Hit-Blocks>                    +
+       <Local-Read-Blocks>N</Local-Read-Blocks>                  +
+       <Local-Dirtied-Blocks>N</Local-Dirtied-Blocks>            +
+       <Local-Written-Blocks>N</Local-Written-Blocks>            +
+       <Temp-Read-Blocks>N</Temp-Read-Blocks>                    +
+       <Temp-Written-Blocks>N</Temp-Written-Blocks>              +
+     </Planning>                                                 +
+     <Planning-Time>N.N</Planning-Time>                          +
+     <Triggers>                                                  +
+     </Triggers>                                                 +
+     <Execution-Time>N.N</Execution-Time>                        +
+   </Query>                                                      +
  </explain>
 (1 row)
 
 select explain_filter('explain (analyze, serialize, buffers, format yaml) select * from int8_tbl i8');
-        explain_filter         
--------------------------------
- - Plan:                      +
-     Node Type: "Seq Scan"    +
-     Parallel Aware: false    +
-     Async Capable: false     +
-     Relation Name: "int8_tbl"+
-     Alias: "i8"              +
-     Startup Cost: N.N        +
-     Total Cost: N.N          +
-     Plan Rows: N             +
-     Plan Width: N            +
-     Actual Startup Time: N.N +
-     Actual Total Time: N.N   +
-     Actual Rows: N.N         +
-     Actual Loops: N          +
-     Disabled: false          +
-     Shared Hit Blocks: N     +
-     Shared Read Blocks: N    +
-     Shared Dirtied Blocks: N +
-     Shared Written Blocks: N +
-     Local Hit Blocks: N      +
-     Local Read Blocks: N     +
-     Local Dirtied Blocks: N  +
-     Local Written Blocks: N  +
-     Temp Read Blocks: N      +
-     Temp Written Blocks: N   +
-   Planning:                  +
-     Shared Hit Blocks: N     +
-     Shared Read Blocks: N    +
-     Shared Dirtied Blocks: N +
-     Shared Written Blocks: N +
-     Local Hit Blocks: N      +
-     Local Read Blocks: N     +
-     Local Dirtied Blocks: N  +
-     Local Written Blocks: N  +
-     Temp Read Blocks: N      +
-     Temp Written Blocks: N   +
-   Planning Time: N.N         +
-   Triggers:                  +
-   Serialization:             +
-     Time: N.N                +
-     Output Volume: N         +
-     Format: "text"           +
-     Shared Hit Blocks: N     +
-     Shared Read Blocks: N    +
-     Shared Dirtied Blocks: N +
-     Shared Written Blocks: N +
-     Local Hit Blocks: N      +
-     Local Read Blocks: N     +
-     Local Dirtied Blocks: N  +
-     Local Written Blocks: N  +
-     Temp Read Blocks: N      +
-     Temp Written Blocks: N   +
+          explain_filter           
+-----------------------------------
+ - Plan:                          +
+     Node Type: "Seq Scan"        +
+     Parallel Aware: false        +
+     Async Capable: false         +
+     Relation Name: "int8_tbl"    +
+     Alias: "i8"                  +
+     Startup Cost: N.N            +
+     Total Cost: N.N              +
+     Plan Rows: N                 +
+     Plan Width: N                +
+     Actual Startup Time: N.N     +
+     Actual Total Time: N.N       +
+     Actual Rows: N.N             +
+     Actual Loops: N              +
+     Disabled: false              +
+     Shared Hit Blocks: N         +
+     Shared Hit Distinct Blocks: N+
+     Shared Read Blocks: N        +
+     Shared Dirtied Blocks: N     +
+     Shared Written Blocks: N     +
+     Local Hit Blocks: N          +
+     Local Read Blocks: N         +
+     Local Dirtied Blocks: N      +
+     Local Written Blocks: N      +
+     Temp Read Blocks: N          +
+     Temp Written Blocks: N       +
+   Planning:                      +
+     Shared Hit Blocks: N         +
+     Shared Read Blocks: N        +
+     Shared Dirtied Blocks: N     +
+     Shared Written Blocks: N     +
+     Local Hit Blocks: N          +
+     Local Read Blocks: N         +
+     Local Dirtied Blocks: N      +
+     Local Written Blocks: N      +
+     Temp Read Blocks: N          +
+     Temp Written Blocks: N       +
+   Planning Time: N.N             +
+   Triggers:                      +
+   Serialization:                 +
+     Time: N.N                    +
+     Output Volume: N             +
+     Format: "text"               +
+     Shared Hit Blocks: N         +
+     Shared Read Blocks: N        +
+     Shared Dirtied Blocks: N     +
+     Shared Written Blocks: N     +
+     Local Hit Blocks: N          +
+     Local Read Blocks: N         +
+     Local Dirtied Blocks: N      +
+     Local Written Blocks: N      +
+     Temp Read Blocks: N          +
+     Temp Written Blocks: N       +
    Execution Time: N.N
 (1 row)
 
@@ -283,65 +285,66 @@ select explain_filter('explain verbose select sum(unique1) over w1, sum(unique2)
 -- but always set in JSON format, so check them only in this case.
 set track_io_timing = on;
 select explain_filter('explain (analyze, buffers, format json) select * from int8_tbl i8');
-           explain_filter            
--------------------------------------
- [                                  +
-   {                                +
-     "Plan": {                      +
-       "Node Type": "Seq Scan",     +
-       "Parallel Aware": false,     +
-       "Async Capable": false,      +
-       "Relation Name": "int8_tbl", +
-       "Alias": "i8",               +
-       "Startup Cost": N.N,         +
-       "Total Cost": N.N,           +
-       "Plan Rows": N,              +
-       "Plan Width": N,             +
-       "Actual Startup Time": N.N,  +
-       "Actual Total Time": N.N,    +
-       "Actual Rows": N.N,          +
-       "Actual Loops": N,           +
-       "Disabled": false,           +
-       "Shared Hit Blocks": N,      +
-       "Shared Read Blocks": N,     +
-       "Shared Dirtied Blocks": N,  +
-       "Shared Written Blocks": N,  +
-       "Local Hit Blocks": N,       +
-       "Local Read Blocks": N,      +
-       "Local Dirtied Blocks": N,   +
-       "Local Written Blocks": N,   +
-       "Temp Read Blocks": N,       +
-       "Temp Written Blocks": N,    +
-       "Shared I/O Read Time": N.N, +
-       "Shared I/O Write Time": N.N,+
-       "Local I/O Read Time": N.N,  +
-       "Local I/O Write Time": N.N, +
-       "Temp I/O Read Time": N.N,   +
-       "Temp I/O Write Time": N.N   +
-     },                             +
-     "Planning": {                  +
-       "Shared Hit Blocks": N,      +
-       "Shared Read Blocks": N,     +
-       "Shared Dirtied Blocks": N,  +
-       "Shared Written Blocks": N,  +
-       "Local Hit Blocks": N,       +
-       "Local Read Blocks": N,      +
-       "Local Dirtied Blocks": N,   +
-       "Local Written Blocks": N,   +
-       "Temp Read Blocks": N,       +
-       "Temp Written Blocks": N,    +
-       "Shared I/O Read Time": N.N, +
-       "Shared I/O Write Time": N.N,+
-       "Local I/O Read Time": N.N,  +
-       "Local I/O Write Time": N.N, +
-       "Temp I/O Read Time": N.N,   +
-       "Temp I/O Write Time": N.N   +
-     },                             +
-     "Planning Time": N.N,          +
-     "Triggers": [                  +
-     ],                             +
-     "Execution Time": N.N          +
-   }                                +
+             explain_filter             
+----------------------------------------
+ [                                     +
+   {                                   +
+     "Plan": {                         +
+       "Node Type": "Seq Scan",        +
+       "Parallel Aware": false,        +
+       "Async Capable": false,         +
+       "Relation Name": "int8_tbl",    +
+       "Alias": "i8",                  +
+       "Startup Cost": N.N,            +
+       "Total Cost": N.N,              +
+       "Plan Rows": N,                 +
+       "Plan Width": N,                +
+       "Actual Startup Time": N.N,     +
+       "Actual Total Time": N.N,       +
+       "Actual Rows": N.N,             +
+       "Actual Loops": N,              +
+       "Disabled": false,              +
+       "Shared Hit Blocks": N,         +
+       "Shared Hit Distinct Blocks": N,+
+       "Shared Read Blocks": N,        +
+       "Shared Dirtied Blocks": N,     +
+       "Shared Written Blocks": N,     +
+       "Local Hit Blocks": N,          +
+       "Local Read Blocks": N,         +
+       "Local Dirtied Blocks": N,      +
+       "Local Written Blocks": N,      +
+       "Temp Read Blocks": N,          +
+       "Temp Written Blocks": N,       +
+       "Shared I/O Read Time": N.N,    +
+       "Shared I/O Write Time": N.N,   +
+       "Local I/O Read Time": N.N,     +
+       "Local I/O Write Time": N.N,    +
+       "Temp I/O Read Time": N.N,      +
+       "Temp I/O Write Time": N.N      +
+     },                                +
+     "Planning": {                     +
+       "Shared Hit Blocks": N,         +
+       "Shared Read Blocks": N,        +
+       "Shared Dirtied Blocks": N,     +
+       "Shared Written Blocks": N,     +
+       "Local Hit Blocks": N,          +
+       "Local Read Blocks": N,         +
+       "Local Dirtied Blocks": N,      +
+       "Local Written Blocks": N,      +
+       "Temp Read Blocks": N,          +
+       "Temp Written Blocks": N,       +
+       "Shared I/O Read Time": N.N,    +
+       "Shared I/O Write Time": N.N,   +
+       "Local I/O Read Time": N.N,     +
+       "Local I/O Write Time": N.N,    +
+       "Temp I/O Read Time": N.N,      +
+       "Temp I/O Write Time": N.N      +
+     },                                +
+     "Planning Time": N.N,             +
+     "Triggers": [                     +
+     ],                                +
+     "Execution Time": N.N             +
+   }                                   +
  ]
 (1 row)
 
@@ -418,55 +421,56 @@ select explain_filter('explain (memory, summary, format yaml) select * from int8
 (1 row)
 
 select explain_filter('explain (memory, analyze, format json) select * from int8_tbl i8');
-           explain_filter           
-------------------------------------
- [                                 +
-   {                               +
-     "Plan": {                     +
-       "Node Type": "Seq Scan",    +
-       "Parallel Aware": false,    +
-       "Async Capable": false,     +
-       "Relation Name": "int8_tbl",+
-       "Alias": "i8",              +
-       "Startup Cost": N.N,        +
-       "Total Cost": N.N,          +
-       "Plan Rows": N,             +
-       "Plan Width": N,            +
-       "Actual Startup Time": N.N, +
-       "Actual Total Time": N.N,   +
-       "Actual Rows": N.N,         +
-       "Actual Loops": N,          +
-       "Disabled": false,          +
-       "Shared Hit Blocks": N,     +
-       "Shared Read Blocks": N,    +
-       "Shared Dirtied Blocks": N, +
-       "Shared Written Blocks": N, +
-       "Local Hit Blocks": N,      +
-       "Local Read Blocks": N,     +
-       "Local Dirtied Blocks": N,  +
-       "Local Written Blocks": N,  +
-       "Temp Read Blocks": N,      +
-       "Temp Written Blocks": N    +
-     },                            +
-     "Planning": {                 +
-       "Shared Hit Blocks": N,     +
-       "Shared Read Blocks": N,    +
-       "Shared Dirtied Blocks": N, +
-       "Shared Written Blocks": N, +
-       "Local Hit Blocks": N,      +
-       "Local Read Blocks": N,     +
-       "Local Dirtied Blocks": N,  +
-       "Local Written Blocks": N,  +
-       "Temp Read Blocks": N,      +
-       "Temp Written Blocks": N,   +
-       "Memory Used": N,           +
-       "Memory Allocated": N       +
-     },                            +
-     "Planning Time": N.N,         +
-     "Triggers": [                 +
-     ],                            +
-     "Execution Time": N.N         +
-   }                               +
+             explain_filter             
+----------------------------------------
+ [                                     +
+   {                                   +
+     "Plan": {                         +
+       "Node Type": "Seq Scan",        +
+       "Parallel Aware": false,        +
+       "Async Capable": false,         +
+       "Relation Name": "int8_tbl",    +
+       "Alias": "i8",                  +
+       "Startup Cost": N.N,            +
+       "Total Cost": N.N,              +
+       "Plan Rows": N,                 +
+       "Plan Width": N,                +
+       "Actual Startup Time": N.N,     +
+       "Actual Total Time": N.N,       +
+       "Actual Rows": N.N,             +
+       "Actual Loops": N,              +
+       "Disabled": false,              +
+       "Shared Hit Blocks": N,         +
+       "Shared Hit Distinct Blocks": N,+
+       "Shared Read Blocks": N,        +
+       "Shared Dirtied Blocks": N,     +
+       "Shared Written Blocks": N,     +
+       "Local Hit Blocks": N,          +
+       "Local Read Blocks": N,         +
+       "Local Dirtied Blocks": N,      +
+       "Local Written Blocks": N,      +
+       "Temp Read Blocks": N,          +
+       "Temp Written Blocks": N        +
+     },                                +
+     "Planning": {                     +
+       "Shared Hit Blocks": N,         +
+       "Shared Read Blocks": N,        +
+       "Shared Dirtied Blocks": N,     +
+       "Shared Written Blocks": N,     +
+       "Local Hit Blocks": N,          +
+       "Local Read Blocks": N,         +
+       "Local Dirtied Blocks": N,      +
+       "Local Written Blocks": N,      +
+       "Temp Read Blocks": N,          +
+       "Temp Written Blocks": N,       +
+       "Memory Used": N,               +
+       "Memory Allocated": N           +
+     },                                +
+     "Planning Time": N.N,             +
+     "Triggers": [                     +
+     ],                                +
+     "Execution Time": N.N             +
+   }                                   +
  ]
 (1 row)
 
@@ -582,7 +586,8 @@ select jsonb_pretty(
                              "Local Dirtied Blocks": 0,     +
                              "Local Written Blocks": 0,     +
                              "Shared Dirtied Blocks": 0,    +
-                             "Shared Written Blocks": 0     +
+                             "Shared Written Blocks": 0,    +
+                             "Shared Hit Distinct Blocks": 0+
                          }                                  +
                      ],                                     +
                      "Output": [                            +
@@ -629,7 +634,8 @@ select jsonb_pretty(
                      "Local Dirtied Blocks": 0,             +
                      "Local Written Blocks": 0,             +
                      "Shared Dirtied Blocks": 0,            +
-                     "Shared Written Blocks": 0             +
+                     "Shared Written Blocks": 0,            +
+                     "Shared Hit Distinct Blocks": 0        +
                  }                                          +
              ],                                             +
              "Output": [                                    +
@@ -673,7 +679,8 @@ select jsonb_pretty(
              "Local Dirtied Blocks": 0,                     +
              "Local Written Blocks": 0,                     +
              "Shared Dirtied Blocks": 0,                    +
-             "Shared Written Blocks": 0                     +
+             "Shared Written Blocks": 0,                    +
+             "Shared Hit Distinct Blocks": 0                +
          },                                                 +
          "Planning": {                                      +
              "Local Hit Blocks": 0,                         +


### PR DESCRIPTION
## TODO

* [ ] Performance testing
  * [x] Can we show that the reduced InstrStopNode effort e.g. speeds up an `EXPLAIN ANALYZE .. COUNT(*) ..`?)
  * [ ] Can we show that parallel query runs faster in regular queries? (since it can now conditionally skip buffer usage measurements)
* [x] Prototype HLL usage for shared buffers hit distinct (mainly to test whether the API is sound for that usage)
* [x] Double check whether the emitted_fpi logic is actually needed (since we do keep the WAL usage counters after all)
* [x] Double check we have no more bugs with Nested Loops counter on the loop node itself
* [x] Add EXPLAIN option for distinct (this may be easiest after Robert's patch is pushed)
* [ ] Consider changing "hit distinct" => "distinct", and including reads
* [ ] Investigate alternatives to modifying utility commands that use internal transactions
  * Idea 1: Can we assign to the portal resource owner, instead of the transaction? (but AFAIK I tried that and it didn't work since the portal resource owner is the initial transaction?)
  * Idea 2: Can we create our own resource owner in places where InstrUsage/InstrStop works with utility statements (i.e. pg_stat_statements utility tracking)
  * Idea 3: Maybe we should keep using top-level buffer counters after all? (and only use the stack to fix the InstrStartNode/InstrStopNode problem)
* [ ] Double check whether the fact that parallel query no longer updates the caller's `pgWalUsage` is a problem (did it actually do that before, or just update the instrumentation struct?)
* [x] Debug test failure
  * ASAN failure? `==53931==ERROR: AddressSanitizer: heap-use-after-free on address 0x625000ab99c0 at pc 0x556c737b6388 bp 0x7ffedc6f6240 sp 0x7ffedc6f6238`
  
  
  ```
    #0 0x556c737b6387 in XLogInsertRecord /tmp/cirrus-ci-build/src/backend/access/transam/xlog.c:1081
    #1 0x556c737c5615 in XLogInsert /tmp/cirrus-ci-build/src/backend/access/transam/xloginsert.c:523
    #2 0x556c737a1811 in XactLogAbortRecord /tmp/cirrus-ci-build/src/backend/access/transam/xact.c:6110
    #3 0x556c737a1cb0 in RecordTransactionAbort /tmp/cirrus-ci-build/src/backend/access/transam/xact.c:1818
    #4 0x556c737a2263 in AbortTransaction /tmp/cirrus-ci-build/src/backend/access/transam/xact.c:2926
    #5 0x556c737a3b35 in AbortCurrentTransactionInternal /tmp/cirrus-ci-build/src/backend/access/transam/xact.c:3495
    #6 0x556c737a3d1d in AbortCurrentTransaction /tmp/cirrus-ci-build/src/backend/access/transam/xact.c:3449
    #7 0x556c74005963 in PostgresMain /tmp/cirrus-ci-build/src/backend/tcop/postgres.c:4408
    #8 0x556c73ff830f in BackendMain /tmp/cirrus-ci-build/src/backend/tcop/backend_startup.c:107
    #9 0x556c73e51e28 in postmaster_child_launch /tmp/cirrus-ci-build/src/backend/postmaster/launch_backend.c:274
    #10 0x556c73e57c89 in BackendStartup /tmp/cirrus-ci-build/src/backend/postmaster/postmaster.c:3519
    #11 0x556c73e5a915 in ServerLoop /tmp/cirrus-ci-build/src/backend/postmaster/postmaster.c:1688
    #12 0x556c73e5ca5a in PostmasterMain /tmp/cirrus-ci-build/src/backend/postmaster/postmaster.c:1386
    #13 0x556c73bf88ea in main /tmp/cirrus-ci-build/src/backend/main/main.c:230
    #14 0x7f8b30248249  (/lib/x86_64-linux-gnu/libc.so.6+0x27249)
    #15 0x7f8b30248304 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x27304)
    #16 0x556c735d53a0 in _start (/tmp/cirrus-ci-build/tmp_install/usr/local/pgsql/bin/postgres+0x4233a0)
    ```