### PR TITLE
Use stack for instrumentation, add EXPLAIN (BUFFERS DISTINCT)

### DIFF
--- a/src/backend/access/brin/brin.c
+++ b/src/backend/access/brin/brin.c
@@ -47,8 +47,7 @@
 #define PARALLEL_KEY_BRIN_SHARED		UINT64CONST(0xB000000000000001)
 #define PARALLEL_KEY_TUPLESORT			UINT64CONST(0xB000000000000002)
 #define PARALLEL_KEY_QUERY_TEXT			UINT64CONST(0xB000000000000003)
-#define PARALLEL_KEY_WAL_USAGE			UINT64CONST(0xB000000000000004)
-#define PARALLEL_KEY_BUFFER_USAGE		UINT64CONST(0xB000000000000005)
+#define PARALLEL_KEY_INSTR_USAGE		UINT64CONST(0xB000000000000004)
 
 /*
  * Status for index builds performed in parallel.  This is allocated in a
@@ -144,8 +143,7 @@ typedef struct BrinLeader
 	BrinShared *brinshared;
 	Sharedsort *sharedsort;
 	Snapshot	snapshot;
-	WalUsage   *walusage;
-	BufferUsage *bufferusage;
+	InstrumentUsage *instrusage;
 } BrinLeader;
 
 /*
@@ -2371,8 +2369,7 @@ _brin_begin_parallel(BrinBuildState *buildstate, Relation heap, Relation index,
 	BrinShared *brinshared;
 	Sharedsort *sharedsort;
 	BrinLeader *brinleader = (BrinLeader *) palloc0(sizeof(BrinLeader));
-	WalUsage   *walusage;
-	BufferUsage *bufferusage;
+	InstrumentUsage *instrusage = NULL;
 	bool		leaderparticipates = true;
 	int			querylen;
 
@@ -2414,19 +2411,14 @@ _brin_begin_parallel(BrinBuildState *buildstate, Relation heap, Relation index,
 	shm_toc_estimate_keys(&pcxt->estimator, 2);
 
 	/*
-	 * Estimate space for WalUsage and BufferUsage -- PARALLEL_KEY_WAL_USAGE
-	 * and PARALLEL_KEY_BUFFER_USAGE.
-	 *
-	 * If there are no extensions loaded that care, we could skip this.  We
-	 * have no way of knowing whether anyone's looking at pgWalUsage or
-	 * pgBufferUsage, so do it unconditionally.
+	 * Estimate space for InstrUsage -- PARALLEL_KEY_INSTR_USAGE, if needed.
 	 */
-	shm_toc_estimate_chunk(&pcxt->estimator,
-						   mul_size(sizeof(WalUsage), pcxt->nworkers));
-	shm_toc_estimate_keys(&pcxt->estimator, 1);
-	shm_toc_estimate_chunk(&pcxt->estimator,
-						   mul_size(sizeof(BufferUsage), pcxt->nworkers));
-	shm_toc_estimate_keys(&pcxt->estimator, 1);
+	if (InstrumentUsageActive())
+	{
+		shm_toc_estimate_chunk(&pcxt->estimator,
+							   mul_size(sizeof(InstrumentUsage), pcxt->nworkers));
+		shm_toc_estimate_keys(&pcxt->estimator, 1);
+	}
 
 	/* Finally, estimate PARALLEL_KEY_QUERY_TEXT space */
 	if (debug_query_string)
@@ -2501,12 +2493,12 @@ _brin_begin_parallel(BrinBuildState *buildstate, Relation heap, Relation index,
 	 * Allocate space for each worker's WalUsage and BufferUsage; no need to
 	 * initialize.
 	 */
-	walusage = shm_toc_allocate(pcxt->toc,
-								mul_size(sizeof(WalUsage), pcxt->nworkers));
-	shm_toc_insert(pcxt->toc, PARALLEL_KEY_WAL_USAGE, walusage);
-	bufferusage = shm_toc_allocate(pcxt->toc,
-								   mul_size(sizeof(BufferUsage), pcxt->nworkers));
-	shm_toc_insert(pcxt->toc, PARALLEL_KEY_BUFFER_USAGE, bufferusage);
+	if (InstrumentUsageActive())
+	{
+		instrusage = shm_toc_allocate(pcxt->toc,
+									  mul_size(sizeof(InstrumentUsage), pcxt->nworkers));
+		shm_toc_insert(pcxt->toc, PARALLEL_KEY_INSTR_USAGE, instrusage);
+	}
 
 	/* Launch workers, saving status for leader/caller */
 	LaunchParallelWorkers(pcxt);
@@ -2517,8 +2509,7 @@ _brin_begin_parallel(BrinBuildState *buildstate, Relation heap, Relation index,
 	brinleader->brinshared = brinshared;
 	brinleader->sharedsort = sharedsort;
 	brinleader->snapshot = snapshot;
-	brinleader->walusage = walusage;
-	brinleader->bufferusage = bufferusage;
+	brinleader->instrusage = instrusage;
 
 	/* If no workers were successfully launched, back out (do serial build) */
 	if (pcxt->nworkers_launched == 0)
@@ -2553,11 +2544,14 @@ _brin_end_parallel(BrinLeader *brinleader, BrinBuildState *state)
 	WaitForParallelWorkersToFinish(brinleader->pcxt);
 
 	/*
-	 * Next, accumulate WAL usage.  (This must wait for the workers to finish,
-	 * or we might get incomplete data.)
+	 * Next, accumulate usage data.  (This must wait for the workers to
+	 * finish, or we might get incomplete data.)
 	 */
-	for (i = 0; i < brinleader->pcxt->nworkers_launched; i++)
-		InstrAccumParallelQuery(&brinleader->bufferusage[i], &brinleader->walusage[i]);
+	if (InstrumentUsageActive())
+	{
+		for (i = 0; i < brinleader->pcxt->nworkers_launched; i++)
+			InstrUsageAddToCurrent(&brinleader->instrusage[i]);
+	}
 
 	/* Free last reference to MVCC snapshot, if one was used */
 	if (IsMVCCSnapshot(brinleader->snapshot))
@@ -2870,8 +2864,7 @@ _brin_parallel_build_main(dsm_segment *seg, shm_toc *toc)
 	Relation	indexRel;
 	LOCKMODE	heapLockmode;
 	LOCKMODE	indexLockmode;
-	WalUsage   *walusage;
-	BufferUsage *bufferusage;
+	InstrumentUsage *shm_usage;
 	int			sortmem;
 
 	/*
@@ -2918,8 +2911,10 @@ _brin_parallel_build_main(dsm_segment *seg, shm_toc *toc)
 	sharedsort = shm_toc_lookup(toc, PARALLEL_KEY_TUPLESORT, false);
 	tuplesort_attach_shared(sharedsort, seg);
 
-	/* Prepare to track buffer usage during parallel execution */
-	InstrStartParallelQuery();
+	/* Prepare to track buffer usage during parallel execution, if needed */
+	shm_usage = shm_toc_lookup(toc, PARALLEL_KEY_INSTR_USAGE, true);
+	if (shm_usage)
+		InstrUsageStart();
 
 	/*
 	 * Might as well use reliable figure when doling out maintenance_work_mem
@@ -2932,10 +2927,12 @@ _brin_parallel_build_main(dsm_segment *seg, shm_toc *toc)
 								  heapRel, indexRel, sortmem, false);
 
 	/* Report WAL/buffer usage during parallel execution */
-	bufferusage = shm_toc_lookup(toc, PARALLEL_KEY_BUFFER_USAGE, false);
-	walusage = shm_toc_lookup(toc, PARALLEL_KEY_WAL_USAGE, false);
-	InstrEndParallelQuery(&bufferusage[ParallelWorkerNumber],
-						  &walusage[ParallelWorkerNumber]);
+	if (shm_usage)
+	{
+		InstrumentUsage *usage = InstrUsageStop();
+
+		memcpy(&shm_usage[ParallelWorkerNumber], usage, sizeof(InstrumentUsage));
+	}
 
 	index_close(indexRel, indexLockmode);
 	table_close(heapRel, heapLockmode);

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -4928,6 +4928,25 @@ AbortOutOfAnyTransaction(void)
 				 * we need to shut down before doing CleanupTransaction.
 				 */
 				AtAbort_Portals();
+
+				/*
+				 * Release any resources that were initialized after an
+				 * earlier AbortTransaction and as such would otherwise leak.
+				 *
+				 * AtAbort_Portals initially unsets the portal's resowner
+				 * since it assumes it called inside AbortTransaction, which
+				 * is not the case here.
+				 */
+				ResourceOwnerRelease(TopTransactionResourceOwner,
+									 RESOURCE_RELEASE_BEFORE_LOCKS,
+									 false, true);
+				ResourceOwnerRelease(TopTransactionResourceOwner,
+									 RESOURCE_RELEASE_LOCKS,
+									 false, true);
+				ResourceOwnerRelease(TopTransactionResourceOwner,
+									 RESOURCE_RELEASE_AFTER_LOCKS,
+									 false, true);
+
 				CleanupTransaction();
 				s->blockState = TBLOCK_DEFAULT;
 				break;

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -1078,6 +1078,9 @@ XLogInsertRecord(XLogRecData *rdata,
 	/* Report WAL traffic to the instrumentation. */
 	if (inserted)
 	{
+		INSTR_WALUSAGE_ADD(wal_bytes, rechdr->xl_tot_len);
+		INSTR_WALUSAGE_INCR(wal_records);
+		INSTR_WALUSAGE_ADD(wal_fpi, num_fpi);
 		pgWalUsage.wal_bytes += rechdr->xl_tot_len;
 		pgWalUsage.wal_records++;
 		pgWalUsage.wal_fpi += num_fpi;
@@ -2060,6 +2063,7 @@ AdvanceXLInsertBuffer(XLogRecPtr upto, TimeLineID tli, bool opportunistic)
 					WriteRqst.Flush = 0;
 					XLogWrite(WriteRqst, tli, false);
 					LWLockRelease(WALWriteLock);
+					INSTR_WALUSAGE_INCR(wal_buffers_full);
 					pgWalUsage.wal_buffers_full++;
 					TRACE_POSTGRESQL_WAL_BUFFER_WRITE_DIRTY_DONE();
 

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -302,9 +302,6 @@ do_analyze_rel(Relation onerel, const VacuumParams params,
 	Oid			save_userid;
 	int			save_sec_context;
 	int			save_nestlevel;
-	WalUsage	startwalusage = pgWalUsage;
-	BufferUsage startbufferusage = pgBufferUsage;
-	BufferUsage bufferusage;
 	PgStat_Counter startreadtime = 0;
 	PgStat_Counter startwritetime = 0;
 
@@ -354,6 +351,7 @@ do_analyze_rel(Relation onerel, const VacuumParams params,
 			startwritetime = pgStatBlockWriteTime;
 		}
 
+		InstrUsageStart();
 		pg_rusage_init(&ru0);
 	}
 
@@ -734,13 +732,17 @@ do_analyze_rel(Relation onerel, const VacuumParams params,
 	if (instrument)
 	{
 		TimestampTz endtime = GetCurrentTimestamp();
+		InstrumentUsage *usage;
+
+		/* support summary tracking of utility statements by extensions */
+		InstrUsageAccumToPrevious();
+		usage = InstrUsageStop();
 
 		if (verbose || params.log_min_duration == 0 ||
 			TimestampDifferenceExceeds(starttime, endtime,
 									   params.log_min_duration))
 		{
 			long		delay_in_ms;
-			WalUsage	walusage;
 			double		read_rate = 0;
 			double		write_rate = 0;
 			char	   *msgfmt;
@@ -749,17 +751,12 @@ do_analyze_rel(Relation onerel, const VacuumParams params,
 			int64		total_blks_read;
 			int64		total_blks_dirtied;
 
-			memset(&bufferusage, 0, sizeof(BufferUsage));
-			BufferUsageAccumDiff(&bufferusage, &pgBufferUsage, &startbufferusage);
-			memset(&walusage, 0, sizeof(WalUsage));
-			WalUsageAccumDiff(&walusage, &pgWalUsage, &startwalusage);
-
-			total_blks_hit = bufferusage.shared_blks_hit +
-				bufferusage.local_blks_hit;
-			total_blks_read = bufferusage.shared_blks_read +
-				bufferusage.local_blks_read;
-			total_blks_dirtied = bufferusage.shared_blks_dirtied +
-				bufferusage.local_blks_dirtied;
+			total_blks_hit = usage->bufusage.shared_blks_hit +
+				usage->bufusage.local_blks_hit;
+			total_blks_read = usage->bufusage.shared_blks_read +
+				usage->bufusage.local_blks_read;
+			total_blks_dirtied = usage->bufusage.shared_blks_dirtied +
+				usage->bufusage.local_blks_dirtied;
 
 			/*
 			 * We do not expect an analyze to take > 25 days and it simplifies
@@ -832,10 +829,10 @@ do_analyze_rel(Relation onerel, const VacuumParams params,
 							 total_blks_dirtied);
 			appendStringInfo(&buf,
 							 _("WAL usage: %" PRId64 " records, %" PRId64 " full page images, %" PRIu64 " bytes, %" PRId64 " buffers full\n"),
-							 walusage.wal_records,
-							 walusage.wal_fpi,
-							 walusage.wal_bytes,
-							 walusage.wal_buffers_full);
+							 usage->walusage.wal_records,
+							 usage->walusage.wal_fpi,
+							 usage->walusage.wal_bytes,
+							 usage->walusage.wal_buffers_full);
 			appendStringInfo(&buf, _("system usage: %s"), pg_rusage_show(&ru0));
 
 			ereport(verbose ? INFO : LOG,

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -143,7 +143,7 @@ static void show_instrumentation_count(const char *qlabel, int which,
 static void show_foreignscan_info(ForeignScanState *fsstate, ExplainState *es);
 static const char *explain_get_index_name(Oid indexId);
 static bool peek_buffer_usage(ExplainState *es, const BufferUsage *usage);
-static void show_buffer_usage(ExplainState *es, const BufferUsage *usage);
+static void show_buffer_usage(ExplainState *es, const BufferUsage *usage, hyperLogLogState *shared_blks_hit_distinct);
 static void show_wal_usage(ExplainState *es, const WalUsage *usage);
 static void show_memory_counters(ExplainState *es,
 								 const MemoryContextCounters *mem_counters);
@@ -323,8 +323,7 @@ standard_ExplainOneQuery(Query *query, int cursorOptions,
 	PlannedStmt *plan;
 	instr_time	planstart,
 				planduration;
-	BufferUsage bufusage_start,
-				bufusage;
+	InstrumentUsage *usage = NULL;
 	MemoryContextCounters mem_counters;
 	MemoryContext planner_ctx = NULL;
 	MemoryContext saved_ctx = NULL;
@@ -346,7 +345,7 @@ standard_ExplainOneQuery(Query *query, int cursorOptions,
 	}
 
 	if (es->buffers)
-		bufusage_start = pgBufferUsage;
+		InstrUsageStart();
 	INSTR_TIME_SET_CURRENT(planstart);
 
 	/* plan the query */
@@ -361,16 +360,16 @@ standard_ExplainOneQuery(Query *query, int cursorOptions,
 		MemoryContextMemConsumed(planner_ctx, &mem_counters);
 	}
 
-	/* calc differences of buffer counters. */
 	if (es->buffers)
 	{
-		memset(&bufusage, 0, sizeof(BufferUsage));
-		BufferUsageAccumDiff(&bufusage, &pgBufferUsage, &bufusage_start);
+		/* support summary tracking of utility statements by extensions */
+		InstrUsageAccumToPrevious();
+		usage = InstrUsageStop();
 	}
 
 	/* run it (if needed) and produce output */
 	ExplainOnePlan(plan, into, es, queryString, params, queryEnv,
-				   &planduration, (es->buffers ? &bufusage : NULL),
+				   &planduration, (es->buffers ? &usage->bufusage : NULL),
 				   es->memory ? &mem_counters : NULL);
 }
 
@@ -514,6 +513,8 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
 
 	if (es->buffers)
 		instrument_option |= INSTRUMENT_BUFFERS;
+	if (es->buffers_distinct)
+		instrument_option |= INSTRUMENT_SHARED_HIT_DISTINCT;
 	if (es->wal)
 		instrument_option |= INSTRUMENT_WAL;
 
@@ -610,7 +611,7 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
 		}
 
 		if (bufusage)
-			show_buffer_usage(es, bufusage);
+			show_buffer_usage(es, bufusage, NULL);
 
 		if (mem_counters)
 			show_memory_counters(es, mem_counters);
@@ -1027,7 +1028,7 @@ ExplainPrintSerialize(ExplainState *es, SerializeMetrics *metrics)
 		if (es->buffers && peek_buffer_usage(es, &metrics->bufferUsage))
 		{
 			es->indent++;
-			show_buffer_usage(es, &metrics->bufferUsage);
+			show_buffer_usage(es, &metrics->bufferUsage, NULL);
 			es->indent--;
 		}
 	}
@@ -1041,7 +1042,7 @@ ExplainPrintSerialize(ExplainState *es, SerializeMetrics *metrics)
 								BYTES_TO_KILOBYTES(metrics->bytesSent), es);
 		ExplainPropertyText("Format", format, es);
 		if (es->buffers)
-			show_buffer_usage(es, &metrics->bufferUsage);
+			show_buffer_usage(es, &metrics->bufferUsage, NULL);
 	}
 
 	ExplainCloseGroup("Serialization", "Serialization", true, es);
@@ -2283,9 +2284,9 @@ ExplainNode(PlanState *planstate, List *ancestors,
 
 	/* Show buffer/WAL usage */
 	if (es->buffers && planstate->instrument)
-		show_buffer_usage(es, &planstate->instrument->bufusage);
+		show_buffer_usage(es, &planstate->instrument->instrusage.bufusage, planstate->instrument->instrusage.shared_blks_hit_distinct);
 	if (es->wal && planstate->instrument)
-		show_wal_usage(es, &planstate->instrument->walusage);
+		show_wal_usage(es, &planstate->instrument->instrusage.walusage);
 
 	/* Prepare per-worker buffer/WAL usage */
 	if (es->workers_state && (es->buffers || es->wal) && es->verbose)
@@ -2302,9 +2303,9 @@ ExplainNode(PlanState *planstate, List *ancestors,
 
 			ExplainOpenWorker(n, es);
 			if (es->buffers)
-				show_buffer_usage(es, &instrument->bufusage);
+				show_buffer_usage(es, &instrument->instrusage.bufusage, NULL);
 			if (es->wal)
-				show_wal_usage(es, &instrument->walusage);
+				show_wal_usage(es, &instrument->instrusage.walusage);
 			ExplainCloseWorker(n, es);
 		}
 	}
@@ -4102,7 +4103,7 @@ peek_buffer_usage(ExplainState *es, const BufferUsage *usage)
  * Show buffer usage details.  This better be sync with peek_buffer_usage.
  */
 static void
-show_buffer_usage(ExplainState *es, const BufferUsage *usage)
+show_buffer_usage(ExplainState *es, const BufferUsage *usage, hyperLogLogState *shared_blks_hit_distinct)
 {
 	if (es->format == EXPLAIN_FORMAT_TEXT)
 	{
@@ -4135,6 +4136,9 @@ show_buffer_usage(ExplainState *es, const BufferUsage *usage)
 				if (usage->shared_blks_hit > 0)
 					appendStringInfo(es->str, " hit=%" PRId64,
 									 usage->shared_blks_hit);
+				if (shared_blks_hit_distinct)
+					appendStringInfo(es->str, " hit distinct=%lld",
+									 (long long) estimateHyperLogLog(shared_blks_hit_distinct));
 				if (usage->shared_blks_read > 0)
 					appendStringInfo(es->str, " read=%" PRId64,
 									 usage->shared_blks_read);
@@ -4225,6 +4229,9 @@ show_buffer_usage(ExplainState *es, const BufferUsage *usage)
 	{
 		ExplainPropertyInteger("Shared Hit Blocks", NULL,
 							   usage->shared_blks_hit, es);
+		if (shared_blks_hit_distinct)
+			ExplainPropertyInteger("Shared Hit Distinct Blocks", NULL,
+								   estimateHyperLogLog(shared_blks_hit_distinct), es);
 		ExplainPropertyInteger("Shared Read Blocks", NULL,
 							   usage->shared_blks_read, es);
 		ExplainPropertyInteger("Shared Dirtied Blocks", NULL,

--- a/src/backend/commands/explain_state.c
+++ b/src/backend/commands/explain_state.c
@@ -95,7 +95,13 @@ ParseExplainOptionList(ExplainState *es, List *options, ParseState *pstate)
 		else if (strcmp(opt->defname, "buffers") == 0)
 		{
 			buffers_set = true;
-			es->buffers = defGetBoolean(opt);
+			if (opt->arg != NULL && strcmp(defGetString(opt), "distinct") == 0)
+			{
+				es->buffers = true;
+				es->buffers_distinct = true;
+			}
+			else
+				es->buffers = defGetBoolean(opt);
 		}
 		else if (strcmp(opt->defname, "wal") == 0)
 			es->wal = defGetBoolean(opt);

--- a/src/backend/commands/prepare.c
+++ b/src/backend/commands/prepare.c
@@ -580,8 +580,7 @@ ExplainExecuteQuery(ExecuteStmt *execstmt, IntoClause *into, ExplainState *es,
 	EState	   *estate = NULL;
 	instr_time	planstart;
 	instr_time	planduration;
-	BufferUsage bufusage_start,
-				bufusage;
+	InstrumentUsage *usage = NULL;
 	MemoryContextCounters mem_counters;
 	MemoryContext planner_ctx = NULL;
 	MemoryContext saved_ctx = NULL;
@@ -597,7 +596,7 @@ ExplainExecuteQuery(ExecuteStmt *execstmt, IntoClause *into, ExplainState *es,
 	}
 
 	if (es->buffers)
-		bufusage_start = pgBufferUsage;
+		InstrUsageStart();
 	INSTR_TIME_SET_CURRENT(planstart);
 
 	/* Look it up in the hash table */
@@ -642,12 +641,8 @@ ExplainExecuteQuery(ExecuteStmt *execstmt, IntoClause *into, ExplainState *es,
 		MemoryContextMemConsumed(planner_ctx, &mem_counters);
 	}
 
-	/* calc differences of buffer counters. */
 	if (es->buffers)
-	{
-		memset(&bufusage, 0, sizeof(BufferUsage));
-		BufferUsageAccumDiff(&bufusage, &pgBufferUsage, &bufusage_start);
-	}
+		usage = InstrUsageStop();
 
 	plan_list = cplan->stmt_list;
 
@@ -658,7 +653,7 @@ ExplainExecuteQuery(ExecuteStmt *execstmt, IntoClause *into, ExplainState *es,
 
 		if (pstmt->commandType != CMD_UTILITY)
 			ExplainOnePlan(pstmt, into, es, query_string, paramLI, pstate->p_queryEnv,
-						   &planduration, (es->buffers ? &bufusage : NULL),
+						   &planduration, (es->buffers ? &usage->bufusage : NULL),
 						   es->memory ? &mem_counters : NULL);
 		else
 			ExplainOneUtility(pstmt->utilityStmt, into, es, pstate, paramLI);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -20936,6 +20936,7 @@ ATExecDetachPartition(List **wqueue, AlteredTableInfo *tab, Relation rel,
 		LOCKTAG		tag;
 		char	   *parentrelname;
 		char	   *partrelname;
+		InstrumentUsage *instrusage = NULL;
 
 		/*
 		 * Add a new constraint to the partition being detached, which
@@ -20968,11 +20969,20 @@ ATExecDetachPartition(List **wqueue, AlteredTableInfo *tab, Relation rel,
 		table_close(rel, NoLock);
 		tab->rel = NULL;
 
+		if (InstrumentUsageActive())
+			instrusage = InstrUsageStop();
+
 		/* Make updated catalog entry visible */
 		PopActiveSnapshot();
 		CommitTransactionCommand();
 
 		StartTransactionCommand();
+
+		if (instrusage != NULL)
+		{
+			InstrUsageStart();
+			InstrUsageAddToCurrent(instrusage);
+		}
 
 		/*
 		 * Now wait.  This ensures that all queries that were planned

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -331,7 +331,7 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 
 	/* Allow instrumentation of Executor overall runtime */
 	if (queryDesc->totaltime)
-		InstrStartNode(queryDesc->totaltime);
+		InstrStart(queryDesc->totaltime, true);
 
 	/*
 	 * extract information from the query descriptor and the query feature.
@@ -383,7 +383,11 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 		dest->rShutdown(dest);
 
 	if (queryDesc->totaltime)
-		InstrStopNode(queryDesc->totaltime, estate->es_processed);
+	{
+		/* allow a potential calling EXPLAIN statement to capture the usage */
+		InstrUsageAccumToPrevious();
+		InstrStop(queryDesc->totaltime, estate->es_processed, true);
+	}
 
 	MemoryContextSwitchTo(oldcontext);
 }
@@ -433,7 +437,7 @@ standard_ExecutorFinish(QueryDesc *queryDesc)
 
 	/* Allow instrumentation of Executor overall runtime */
 	if (queryDesc->totaltime)
-		InstrStartNode(queryDesc->totaltime);
+		InstrStart(queryDesc->totaltime, true);
 
 	/* Run ModifyTable nodes to completion */
 	ExecPostprocessPlan(estate);
@@ -443,7 +447,11 @@ standard_ExecutorFinish(QueryDesc *queryDesc)
 		AfterTriggerEndQuery(estate);
 
 	if (queryDesc->totaltime)
-		InstrStopNode(queryDesc->totaltime, 0);
+	{
+		/* allow a potential calling EXPLAIN statement to capture the usage */
+		InstrUsageAccumToPrevious();
+		InstrStop(queryDesc->totaltime, 0, true);
+	}
 
 	MemoryContextSwitchTo(oldcontext);
 

--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -16,15 +16,42 @@
 #include <unistd.h>
 
 #include "executor/instrument.h"
+#include "tcop/pquery.h"
+#include "utils/memutils.h"
 
-BufferUsage pgBufferUsage;
-static BufferUsage save_pgBufferUsage;
 WalUsage	pgWalUsage;
-static WalUsage save_pgWalUsage;
+InstrumentUsage *pgInstrumentUsageStack = NULL;
 
-static void BufferUsageAdd(BufferUsage *dst, const BufferUsage *add);
-static void WalUsageAdd(WalUsage *dst, WalUsage *add);
+static void WalUsageAdd(WalUsage *dst, const WalUsage *add);
 
+/*
+ * To make sure we don't leak, use ResourceOwner mechanism to reset stack on abort.
+ */
+static void PushInstrumentUsage(InstrumentUsage * usage);
+static void PushInstrumentUsageWithOwner(InstrumentUsage * usage);
+static void PopInstrumentUsage(InstrumentUsage * usage);
+static void PopInstrumentUsageWithOwner(InstrumentUsageResource * usage);
+static void ResOwnerReleaseInstrumentUsage(Datum res);
+
+static const ResourceOwnerDesc instrument_usage_resowner_desc =
+{
+	.name = "instrument usage scope",
+	.release_phase = RESOURCE_RELEASE_BEFORE_LOCKS,
+	.release_priority = RELEASE_PRIO_FIRST,
+	.ReleaseResource = ResOwnerReleaseInstrumentUsage,
+	.DebugPrint = NULL,			/* default message is fine */
+};
+
+static inline void
+ResourceOwnerRememberInstrumentUsage(ResourceOwner owner, InstrumentUsageResource * scope)
+{
+	ResourceOwnerRemember(owner, PointerGetDatum(scope), &instrument_usage_resowner_desc);
+}
+static inline void
+ResourceOwnerForgetInstrumentUsage(ResourceOwner owner, InstrumentUsageResource * scope)
+{
+	ResourceOwnerForget(owner, PointerGetDatum(scope), &instrument_usage_resowner_desc);
+}
 
 /* Allocate new instrumentation structure(s) */
 Instrumentation *
@@ -33,12 +60,13 @@ InstrAlloc(int n, int instrument_options, bool async_mode)
 	Instrumentation *instr;
 
 	/* initialize all fields to zeroes, then modify as needed */
-	instr = palloc0(n * sizeof(Instrumentation));
-	if (instrument_options & (INSTRUMENT_BUFFERS | INSTRUMENT_TIMER | INSTRUMENT_WAL))
+	instr = MemoryContextAllocZero(TopTransactionContext, n * sizeof(Instrumentation));
+	if (instrument_options & (INSTRUMENT_BUFFERS | INSTRUMENT_TIMER | INSTRUMENT_WAL | INSTRUMENT_SHARED_HIT_DISTINCT))
 	{
 		bool		need_buffers = (instrument_options & INSTRUMENT_BUFFERS) != 0;
 		bool		need_wal = (instrument_options & INSTRUMENT_WAL) != 0;
 		bool		need_timer = (instrument_options & INSTRUMENT_TIMER) != 0;
+		bool		need_shared_hit_distinct = (instrument_options & INSTRUMENT_SHARED_HIT_DISTINCT) != 0;
 		int			i;
 
 		for (i = 0; i < n; i++)
@@ -46,6 +74,7 @@ InstrAlloc(int n, int instrument_options, bool async_mode)
 			instr[i].need_bufusage = need_buffers;
 			instr[i].need_walusage = need_wal;
 			instr[i].need_timer = need_timer;
+			instr[i].need_shared_hit_distinct = need_shared_hit_distinct;
 			instr[i].async_mode = async_mode;
 		}
 	}
@@ -61,27 +90,40 @@ InstrInit(Instrumentation *instr, int instrument_options)
 	instr->need_bufusage = (instrument_options & INSTRUMENT_BUFFERS) != 0;
 	instr->need_walusage = (instrument_options & INSTRUMENT_WAL) != 0;
 	instr->need_timer = (instrument_options & INSTRUMENT_TIMER) != 0;
+	instr->need_shared_hit_distinct = (instrument_options & INSTRUMENT_SHARED_HIT_DISTINCT) != 0;
+}
+
+void
+InstrStart(Instrumentation *instr, bool use_resowner)
+{
+	if (instr->need_timer &&
+		!INSTR_TIME_SET_CURRENT_LAZY(instr->starttime))
+		elog(ERROR, "InstrStartNode called twice in a row");
+
+	if (instr->need_bufusage || instr->need_walusage || instr->need_shared_hit_distinct)
+	{
+		if (use_resowner)
+			PushInstrumentUsageWithOwner(&instr->instrusage);
+		else
+			PushInstrumentUsage(&instr->instrusage);
+	}
+
+	if (instr->need_shared_hit_distinct && !instr->instrusage.shared_blks_hit_distinct)
+	{
+		instr->instrusage.shared_blks_hit_distinct = palloc0(sizeof(hyperLogLogState));
+		initHyperLogLog(instr->instrusage.shared_blks_hit_distinct, 16);
+	}
 }
 
 /* Entry to a plan node */
 void
 InstrStartNode(Instrumentation *instr)
 {
-	if (instr->need_timer &&
-		!INSTR_TIME_SET_CURRENT_LAZY(instr->starttime))
-		elog(ERROR, "InstrStartNode called twice in a row");
-
-	/* save buffer usage totals at node entry, if needed */
-	if (instr->need_bufusage)
-		instr->bufusage_start = pgBufferUsage;
-
-	if (instr->need_walusage)
-		instr->walusage_start = pgWalUsage;
+	InstrStart(instr, false);
 }
 
-/* Exit from a plan node */
 void
-InstrStopNode(Instrumentation *instr, double nTuples)
+InstrStop(Instrumentation *instr, double nTuples, bool use_resowner)
 {
 	double		save_tuplecount = instr->tuplecount;
 	instr_time	endtime;
@@ -101,14 +143,13 @@ InstrStopNode(Instrumentation *instr, double nTuples)
 		INSTR_TIME_SET_ZERO(instr->starttime);
 	}
 
-	/* Add delta of buffer usage since entry to node's totals */
-	if (instr->need_bufusage)
-		BufferUsageAccumDiff(&instr->bufusage,
-							 &pgBufferUsage, &instr->bufusage_start);
-
-	if (instr->need_walusage)
-		WalUsageAccumDiff(&instr->walusage,
-						  &pgWalUsage, &instr->walusage_start);
+	if (instr->need_bufusage || instr->need_walusage || instr->need_shared_hit_distinct)
+	{
+		if (use_resowner)
+			PopInstrumentUsageWithOwner(instr->instrusage.res);
+		else
+			PopInstrumentUsage(&instr->instrusage);
+	}
 
 	/* Is this the first tuple of this cycle? */
 	if (!instr->running)
@@ -125,6 +166,13 @@ InstrStopNode(Instrumentation *instr, double nTuples)
 		if (instr->async_mode && save_tuplecount < 1.0)
 			instr->firsttuple = INSTR_TIME_GET_DOUBLE(instr->counter);
 	}
+}
+
+/* Exit from a plan node */
+void
+InstrStopNode(Instrumentation *instr, double nTuples)
+{
+	InstrStop(instr, nTuples, false);
 }
 
 /* Update tuple count */
@@ -187,42 +235,115 @@ InstrAggNode(Instrumentation *dst, Instrumentation *add)
 	dst->nfiltered1 += add->nfiltered1;
 	dst->nfiltered2 += add->nfiltered2;
 
-	/* Add delta of buffer usage since entry to node's totals */
-	if (dst->need_bufusage)
-		BufferUsageAdd(&dst->bufusage, &add->bufusage);
-
-	if (dst->need_walusage)
-		WalUsageAdd(&dst->walusage, &add->walusage);
+	/* Add delta of buffer/WAL usage since entry to node's totals */
+	if (dst->need_bufusage || dst->need_walusage)
+		InstrUsageAdd(&dst->instrusage, &add->instrusage);
 }
 
-/* note current values during parallel executor startup */
-void
-InstrStartParallelQuery(void)
+static void
+PushInstrumentUsage(InstrumentUsage * usage)
 {
-	save_pgBufferUsage = pgBufferUsage;
-	save_pgWalUsage = pgWalUsage;
+	usage->previous = pgInstrumentUsageStack;
+	pgInstrumentUsageStack = usage;
 }
 
-/* report usage after parallel executor shutdown */
-void
-InstrEndParallelQuery(BufferUsage *bufusage, WalUsage *walusage)
+static void
+PushInstrumentUsageWithOwner(InstrumentUsage * usage)
 {
-	memset(bufusage, 0, sizeof(BufferUsage));
-	BufferUsageAccumDiff(bufusage, &pgBufferUsage, &save_pgBufferUsage);
-	memset(walusage, 0, sizeof(WalUsage));
-	WalUsageAccumDiff(walusage, &pgWalUsage, &save_pgWalUsage);
+	InstrumentUsageResource *usageRes = MemoryContextAllocZero(TopTransactionContext, sizeof(InstrumentUsageResource));
+	ResourceOwner owner = CurrentResourceOwner;
+
+	Assert(owner != NULL);
+
+	usageRes->previous = pgInstrumentUsageStack;
+	usageRes->owner = owner;
+
+	ResourceOwnerEnlarge(owner);
+	ResourceOwnerRememberInstrumentUsage(owner, usageRes);
+
+	usage->res = usageRes;
+	PushInstrumentUsage(usage);
 }
 
-/* accumulate work done by workers in leader's stats */
-void
-InstrAccumParallelQuery(BufferUsage *bufusage, WalUsage *walusage)
+static void
+PopInstrumentUsage(InstrumentUsage * usage)
 {
-	BufferUsageAdd(&pgBufferUsage, bufusage);
-	WalUsageAdd(&pgWalUsage, walusage);
+	pgInstrumentUsageStack = usage->previous;
+}
+
+static void
+PopInstrumentUsageWithOwner(InstrumentUsageResource * usageRes)
+{
+	pgInstrumentUsageStack = usageRes->previous;
+	Assert(usageRes != NULL);
+	if (usageRes->owner != NULL)
+		ResourceOwnerForgetInstrumentUsage(usageRes->owner, usageRes);
+	pfree(usageRes);
+}
+
+static void
+ResOwnerReleaseInstrumentUsage(Datum res)
+{
+	InstrumentUsageResource *usageRes = (InstrumentUsageResource *) DatumGetPointer(res);
+
+	usageRes->owner = NULL;
+	PopInstrumentUsageWithOwner(usageRes);
+}
+
+/* Start buffer/WAL usage measurement */
+void
+InstrUsageStart()
+{
+	InstrumentUsage *usage = MemoryContextAllocZero(TopTransactionContext, sizeof(InstrumentUsage));
+
+	PushInstrumentUsageWithOwner(usage);
+}
+
+/*
+ * Call this before calling stop to add the usage metrics to the previous item
+ * on the stack (if it exists)
+ */
+void
+InstrUsageAccumToPrevious()
+{
+	if (!pgInstrumentUsageStack || !pgInstrumentUsageStack->previous)
+		return;
+
+	InstrUsageAdd(pgInstrumentUsageStack->previous, pgInstrumentUsageStack);
+}
+
+/* Stop usage measurement and return results */
+InstrumentUsage *
+InstrUsageStop()
+{
+	InstrumentUsage *result = pgInstrumentUsageStack;
+
+	Assert(result != NULL);
+	PopInstrumentUsageWithOwner(result->res);
+
+	/* Avoid returning references that were freed */
+	result->res = NULL;
+	result->previous = NULL;
+
+	return result;
+}
+
+void
+InstrUsageAdd(InstrumentUsage * dst, const InstrumentUsage * add)
+{
+	BufferUsageAdd(&dst->bufusage, &add->bufusage);
+	WalUsageAdd(&dst->walusage, &add->walusage);
+}
+
+void
+InstrUsageAddToCurrent(InstrumentUsage * instrusage)
+{
+	if (pgInstrumentUsageStack != NULL)
+		InstrUsageAdd(pgInstrumentUsageStack, instrusage);
 }
 
 /* dst += add */
-static void
+void
 BufferUsageAdd(BufferUsage *dst, const BufferUsage *add)
 {
 	dst->shared_blks_hit += add->shared_blks_hit;
@@ -243,39 +364,9 @@ BufferUsageAdd(BufferUsage *dst, const BufferUsage *add)
 	INSTR_TIME_ADD(dst->temp_blk_write_time, add->temp_blk_write_time);
 }
 
-/* dst += add - sub */
-void
-BufferUsageAccumDiff(BufferUsage *dst,
-					 const BufferUsage *add,
-					 const BufferUsage *sub)
-{
-	dst->shared_blks_hit += add->shared_blks_hit - sub->shared_blks_hit;
-	dst->shared_blks_read += add->shared_blks_read - sub->shared_blks_read;
-	dst->shared_blks_dirtied += add->shared_blks_dirtied - sub->shared_blks_dirtied;
-	dst->shared_blks_written += add->shared_blks_written - sub->shared_blks_written;
-	dst->local_blks_hit += add->local_blks_hit - sub->local_blks_hit;
-	dst->local_blks_read += add->local_blks_read - sub->local_blks_read;
-	dst->local_blks_dirtied += add->local_blks_dirtied - sub->local_blks_dirtied;
-	dst->local_blks_written += add->local_blks_written - sub->local_blks_written;
-	dst->temp_blks_read += add->temp_blks_read - sub->temp_blks_read;
-	dst->temp_blks_written += add->temp_blks_written - sub->temp_blks_written;
-	INSTR_TIME_ACCUM_DIFF(dst->shared_blk_read_time,
-						  add->shared_blk_read_time, sub->shared_blk_read_time);
-	INSTR_TIME_ACCUM_DIFF(dst->shared_blk_write_time,
-						  add->shared_blk_write_time, sub->shared_blk_write_time);
-	INSTR_TIME_ACCUM_DIFF(dst->local_blk_read_time,
-						  add->local_blk_read_time, sub->local_blk_read_time);
-	INSTR_TIME_ACCUM_DIFF(dst->local_blk_write_time,
-						  add->local_blk_write_time, sub->local_blk_write_time);
-	INSTR_TIME_ACCUM_DIFF(dst->temp_blk_read_time,
-						  add->temp_blk_read_time, sub->temp_blk_read_time);
-	INSTR_TIME_ACCUM_DIFF(dst->temp_blk_write_time,
-						  add->temp_blk_write_time, sub->temp_blk_write_time);
-}
-
 /* helper functions for WAL usage accumulation */
 static void
-WalUsageAdd(WalUsage *dst, WalUsage *add)
+WalUsageAdd(WalUsage *dst, const WalUsage *add)
 {
 	dst->wal_bytes += add->wal_bytes;
 	dst->wal_records += add->wal_records;

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -1864,6 +1864,7 @@ opt_boolean_or_string:
 			TRUE_P									{ $$ = "true"; }
 			| FALSE_P								{ $$ = "false"; }
 			| ON									{ $$ = "on"; }
+			| DISTINCT								{ $$ = "distinct"; }
 			/*
 			 * OFF is also accepted as a boolean value, but is handled by
 			 * the NonReservedWord rule.  The action for booleans and strings

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -705,7 +705,7 @@ ReadRecentBuffer(RelFileLocator rlocator, ForkNumber forkNum, BlockNumber blockN
 		{
 			PinLocalBuffer(bufHdr, true);
 
-			pgBufferUsage.local_blks_hit++;
+			INSTR_BUFUSAGE_INCR(local_blks_hit);
 
 			return true;
 		}
@@ -737,7 +737,8 @@ ReadRecentBuffer(RelFileLocator rlocator, ForkNumber forkNum, BlockNumber blockN
 			else
 				PinBuffer_Locked(bufHdr);	/* pin for first time */
 
-			pgBufferUsage.shared_blks_hit++;
+			INSTR_BUFUSAGE_INCR(shared_blks_hit);
+			INSTR_BUFUSAGE_COUNT_SHARED_HIT(bufHdr->buf_id);
 
 			return true;
 		}
@@ -1147,14 +1148,14 @@ PinBufferForBlock(Relation rel,
 	{
 		bufHdr = LocalBufferAlloc(smgr, forkNum, blockNum, foundPtr);
 		if (*foundPtr)
-			pgBufferUsage.local_blks_hit++;
+			INSTR_BUFUSAGE_INCR(local_blks_hit);
 	}
 	else
 	{
 		bufHdr = BufferAlloc(smgr, persistence, forkNum, blockNum,
 							 strategy, foundPtr, io_context);
 		if (*foundPtr)
-			pgBufferUsage.shared_blks_hit++;
+			INSTR_BUFUSAGE_COUNT_SHARED_HIT(bufHdr->buf_id);
 	}
 	if (rel)
 	{
@@ -1888,9 +1889,9 @@ AsyncReadBuffers(ReadBuffersOperation *operation, int *nblocks_progress)
 										  true);
 
 		if (persistence == RELPERSISTENCE_TEMP)
-			pgBufferUsage.local_blks_hit += 1;
+			INSTR_BUFUSAGE_INCR(local_blks_hit);
 		else
-			pgBufferUsage.shared_blks_hit += 1;
+			INSTR_BUFUSAGE_COUNT_SHARED_HIT(blocknum);
 
 		if (operation->rel)
 			pgstat_count_buffer_hit(operation->rel);
@@ -1958,9 +1959,9 @@ AsyncReadBuffers(ReadBuffersOperation *operation, int *nblocks_progress)
 								io_start, 1, io_buffers_len * BLCKSZ);
 
 		if (persistence == RELPERSISTENCE_TEMP)
-			pgBufferUsage.local_blks_read += io_buffers_len;
+			INSTR_BUFUSAGE_ADD(local_blks_read, io_buffers_len);
 		else
-			pgBufferUsage.shared_blks_read += io_buffers_len;
+			INSTR_BUFUSAGE_ADD(shared_blks_read, io_buffers_len);
 
 		/*
 		 * Track vacuum cost when issuing IO, not after waiting for it.
@@ -2865,7 +2866,7 @@ ExtendBufferedRelShared(BufferManagerRelation bmr,
 		TerminateBufferIO(buf_hdr, false, BM_VALID, true, false);
 	}
 
-	pgBufferUsage.shared_blks_written += extend_by;
+	INSTR_BUFUSAGE_ADD(shared_blks_written, extend_by);
 
 	*extended_by = extend_by;
 
@@ -2983,7 +2984,7 @@ MarkBufferDirty(Buffer buffer)
 	 */
 	if (!(old_buf_state & BM_DIRTY))
 	{
-		pgBufferUsage.shared_blks_dirtied++;
+		INSTR_BUFUSAGE_INCR(shared_blks_dirtied);
 		if (VacuumCostActive)
 			VacuumCostBalance += VacuumCostPageDirty;
 	}
@@ -4391,7 +4392,7 @@ FlushBuffer(BufferDesc *buf, SMgrRelation reln, IOObject io_object,
 	pgstat_count_io_op_time(IOOBJECT_RELATION, io_context,
 							IOOP_WRITE, io_start, 1, BLCKSZ);
 
-	pgBufferUsage.shared_blks_written++;
+	INSTR_BUFUSAGE_INCR(shared_blks_written);
 
 	/*
 	 * Mark the buffer as clean (unless BM_JUST_DIRTIED has become set) and
@@ -5547,7 +5548,7 @@ MarkBufferDirtyHint(Buffer buffer, bool buffer_std)
 
 		if (dirtied)
 		{
-			pgBufferUsage.shared_blks_dirtied++;
+			INSTR_BUFUSAGE_INCR(shared_blks_dirtied);
 			if (VacuumCostActive)
 				VacuumCostBalance += VacuumCostPageDirty;
 		}

--- a/src/backend/storage/buffer/localbuf.c
+++ b/src/backend/storage/buffer/localbuf.c
@@ -216,7 +216,7 @@ FlushLocalBuffer(BufferDesc *bufHdr, SMgrRelation reln)
 	/* Mark not-dirty */
 	TerminateLocalBufferIO(bufHdr, true, 0, false);
 
-	pgBufferUsage.local_blks_written++;
+	INSTR_BUFUSAGE_INCR(local_blks_written);
 }
 
 static Buffer
@@ -476,7 +476,7 @@ ExtendBufferedRelLocal(BufferManagerRelation bmr,
 
 	*extended_by = extend_by;
 
-	pgBufferUsage.local_blks_written += extend_by;
+	INSTR_BUFUSAGE_ADD(local_blks_written, extend_by);
 
 	return first_block;
 }
@@ -507,7 +507,7 @@ MarkLocalBufferDirty(Buffer buffer)
 	buf_state = pg_atomic_read_u32(&bufHdr->state);
 
 	if (!(buf_state & BM_DIRTY))
-		pgBufferUsage.local_blks_dirtied++;
+		INSTR_BUFUSAGE_INCR(local_blks_dirtied);
 
 	buf_state |= BM_DIRTY;
 

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -474,13 +474,13 @@ BufFileLoadBuffer(BufFile *file)
 	if (track_io_timing)
 	{
 		INSTR_TIME_SET_CURRENT(io_time);
-		INSTR_TIME_ACCUM_DIFF(pgBufferUsage.temp_blk_read_time, io_time, io_start);
+		INSTR_BUFUSAGE_TIME_ACCUM_DIFF(temp_blk_read_time, io_time, io_start);
 	}
 
 	/* we choose not to advance curOffset here */
 
 	if (file->nbytes > 0)
-		pgBufferUsage.temp_blks_read++;
+		INSTR_BUFUSAGE_INCR(temp_blks_read);
 }
 
 /*
@@ -548,13 +548,13 @@ BufFileDumpBuffer(BufFile *file)
 		if (track_io_timing)
 		{
 			INSTR_TIME_SET_CURRENT(io_time);
-			INSTR_TIME_ACCUM_DIFF(pgBufferUsage.temp_blk_write_time, io_time, io_start);
+			INSTR_BUFUSAGE_TIME_ACCUM_DIFF(temp_blk_write_time, io_time, io_start);
 		}
 
 		file->curOffset += bytestowrite;
 		wpos += bytestowrite;
 
-		pgBufferUsage.temp_blks_written++;
+		INSTR_BUFUSAGE_INCR(temp_blks_written);
 	}
 	file->dirty = false;
 

--- a/src/backend/utils/activity/pgstat_io.c
+++ b/src/backend/utils/activity/pgstat_io.c
@@ -135,17 +135,17 @@ pgstat_count_io_op_time(IOObject io_object, IOContext io_context, IOOp io_op,
 			{
 				pgstat_count_buffer_write_time(INSTR_TIME_GET_MICROSEC(io_time));
 				if (io_object == IOOBJECT_RELATION)
-					INSTR_TIME_ADD(pgBufferUsage.shared_blk_write_time, io_time);
+					INSTR_BUFUSAGE_TIME_ADD(shared_blk_write_time, io_time);
 				else if (io_object == IOOBJECT_TEMP_RELATION)
-					INSTR_TIME_ADD(pgBufferUsage.local_blk_write_time, io_time);
+					INSTR_BUFUSAGE_TIME_ADD(local_blk_write_time, io_time);
 			}
 			else if (io_op == IOOP_READ)
 			{
 				pgstat_count_buffer_read_time(INSTR_TIME_GET_MICROSEC(io_time));
 				if (io_object == IOOBJECT_RELATION)
-					INSTR_TIME_ADD(pgBufferUsage.shared_blk_read_time, io_time);
+					INSTR_BUFUSAGE_TIME_ADD(shared_blk_read_time, io_time);
 				else if (io_object == IOOBJECT_TEMP_RELATION)
-					INSTR_TIME_ADD(pgBufferUsage.local_blk_read_time, io_time);
+					INSTR_BUFUSAGE_TIME_ADD(local_blk_read_time, io_time);
 			}
 		}
 

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -155,7 +155,6 @@ extern PGDLLIMPORT bool XLOG_DEBUG;
 #define XLOG_INCLUDE_ORIGIN		0x01	/* include the replication origin */
 #define XLOG_MARK_UNIMPORTANT	0x02	/* record not important for durability */
 
-
 /* Checkpoint statistics */
 typedef struct CheckpointStatsData
 {

--- a/src/include/commands/explain_state.h
+++ b/src/include/commands/explain_state.h
@@ -49,6 +49,8 @@ typedef struct ExplainState
 	bool		analyze;		/* print actual times */
 	bool		costs;			/* print estimated costs */
 	bool		buffers;		/* print buffer usage */
+	bool		buffers_distinct;	/* print estimated distinct shared buffer
+									 * usage */
 	bool		wal;			/* print WAL usage */
 	bool		timing;			/* print detailed node timing */
 	bool		summary;		/* print total planning and execution timing */

--- a/src/include/executor/execParallel.h
+++ b/src/include/executor/execParallel.h
@@ -25,8 +25,7 @@ typedef struct ParallelExecutorInfo
 {
 	PlanState  *planstate;		/* plan subtree we're running in parallel */
 	ParallelContext *pcxt;		/* parallel context we're using */
-	BufferUsage *buffer_usage;	/* points to bufusage area in DSM */
-	WalUsage   *wal_usage;		/* walusage area in DSM */
+	InstrumentUsage *instrusage;	/* points to instrument usage area in DSM */
 	SharedExecutorInstrumentation *instrumentation; /* optional */
 	struct SharedJitInstrumentation *jit_instrumentation;	/* optional */
 	dsa_area   *area;			/* points to DSA area in DSM */


### PR DESCRIPTION
(not submitted for now, instead #23 was submitted to the September commitfest, which excludes the global stack use, and the `EXPLAIN (BUFFERS DISTINCT)` patch)

See earlier notes in https://github.com/lfittl/postgres/pull/14.