### PR TITLE
Fast timing for ARM (v1)

### DIFF
--- a/src/common/instr_time.c
+++ b/src/common/instr_time.c
@@ -20,6 +20,10 @@
 
 #include <math.h>
 
+#if defined(__APPLE__)
+#include <sys/sysctl.h>
+#endif
+
 #include "port/pg_cpu.h"
 #include "portability/instr_time.h"
 
@@ -161,7 +165,7 @@ set_ticks_per_ns_system(void)
 
 #endif							/* WIN32 */
 
-/* TSC specific logic */
+/* Hardware clock specific logic (x86 TSC / AArch64 CNTVCT) */
 
 #if PG_INSTR_TSC_CLOCK
 
@@ -188,6 +192,12 @@ set_ticks_per_ns_for_tsc(void)
 	ticks_per_ns_scaled = ((NS_PER_S / 1000) << TICKS_TO_NS_SHIFT) / timing_tsc_frequency_khz;
 	max_ticks_no_overflow = PG_INT64_MAX / ticks_per_ns_scaled;
 }
+
+#if defined(__x86_64__) || defined(_M_X64)
+
+/*
+ * x86-64 TSC specific logic
+ */
 
 /*
  * Detect the TSC frequency and whether RDTSCP is available on x86-64.
@@ -368,5 +378,60 @@ pg_tsc_calibrate_frequency(void)
 
 	return (uint32) freq_khz;
 }
+
+#elif defined(__aarch64__)
+
+/*
+ * Check whether this is a heterogeneous Apple Silicon P+E core system
+ * where CNTVCT_EL0 may tick at different rates on different core types.
+ */
+static bool
+aarch64_has_heterogeneous_cores(void)
+{
+#if defined(__APPLE__)
+	int			nperflevels = 0;
+	size_t		len = sizeof(nperflevels);
+
+	if (sysctlbyname("hw.nperflevels", &nperflevels, &len, NULL, 0) == 0)
+		return nperflevels > 1;
+#endif
+
+	return false;
+}
+
+/*
+ * Detect the generic timer frequency on AArch64.
+ */
+static void
+tsc_detect_frequency(void)
+{
+	if (aarch64_has_heterogeneous_cores())
+	{
+		timing_tsc_frequency_khz = 0;
+		return;
+	}
+
+	timing_tsc_frequency_khz = aarch64_cntvct_frequency_khz();
+}
+
+/*
+ * The ARM generic timer is architecturally guaranteed to be monotonic and
+ * synchronized across cores of the same type, so we always use it by default
+ * when available and cores are homogenous.
+ */
+static bool
+tsc_use_by_default(void)
+{
+	return true;
+}
+
+uint32
+pg_tsc_calibrate_frequency(void)
+{
+	/* No calibration loop on AArch64; frequency comes from CNTFRQ_EL0 */
+	return 0;
+}
+
+#endif							/* defined(__aarch64__) */
 
 #endif							/* PG_INSTR_TSC_CLOCK */

--- a/src/include/port/pg_cpu.h
+++ b/src/include/port/pg_cpu.h
@@ -60,4 +60,10 @@ extern uint32 x86_tsc_frequency_khz(void);
 
 #endif							/* defined(USE_SSE2) || defined(__i386__) */
 
+#if defined(__aarch64__)
+
+extern uint32 aarch64_cntvct_frequency_khz(void);
+
+#endif							/* defined(__aarch64__) */
+
 #endif							/* PG_CPU_H */

--- a/src/include/portability/instr_time.h
+++ b/src/include/portability/instr_time.h
@@ -4,8 +4,9 @@
  *	  portable high-precision interval timing
  *
  * This file provides an abstraction layer to hide portability issues in
- * interval timing. On x86 we use the RDTSC/RDTSCP instruction directly in
- * certain cases, or alternatively clock_gettime() on Unix-like systems and
+ * interval timing. On x86 we use the RDTSC/RDTSCP instruction, and on
+ * AArch64 the CNTVCT_EL0 generic timer, directly in certain cases, or
+ * alternatively clock_gettime() on Unix-like systems and
  * QueryPerformanceCounter() on Windows. These macros also give some breathing
  * room to use other high-precision-timing APIs.
  *
@@ -95,7 +96,7 @@ typedef struct instr_time
  * PG_INSTR_TSC_CLOCK controls whether the TSC clock source is compiled in, and
  * potentially used based on timing_tsc_enabled.
  */
-#if defined(__x86_64__) || defined(_M_X64)
+#if defined(__x86_64__) || defined(_M_X64) || (defined(__aarch64__) && !defined(_MSC_VER))
 #define PG_INSTR_TICKS_TO_NS 1
 #define PG_INSTR_TSC_CLOCK 1
 #elif defined(WIN32)
@@ -333,6 +334,8 @@ pg_ns_to_ticks(int64 ns)
 
 #if PG_INSTR_TSC_CLOCK
 
+#if defined(__x86_64__) || defined(_M_X64)
+
 #define PG_INSTR_TSC_CLOCK_NAME_FAST  "RDTSC"
 #define PG_INSTR_TSC_CLOCK_NAME "RDTSCP"
 
@@ -396,7 +399,52 @@ pg_get_ticks_fast(void)
 	return pg_get_ticks_system();
 }
 
-#else
+#elif defined(__aarch64__) && !defined(_MSC_VER)
+
+#define PG_INSTR_TSC_CLOCK_NAME_FAST  "CNTVCT_EL0"
+#define PG_INSTR_TSC_CLOCK_NAME "CNTVCT_EL0 (ISB)"
+
+/*
+ * Read the ARM generic timer counter (CNTVCT_EL0).
+ *
+ * The "fast" variant reads the counter without a barrier, analogous to RDTSC
+ * on x86. The regular variant issues an ISB (Instruction Synchronization
+ * Barrier) first, which acts as a serializing instruction analogous to RDTSCP,
+ * ensuring all preceding instructions have completed before reading the
+ * counter.
+ */
+static pg_attribute_always_inline instr_time
+pg_get_ticks(void)
+{
+	if (likely(timing_tsc_enabled))
+	{
+		instr_time	now;
+
+		__builtin_arm_isb(0xf);
+		now.ticks = __builtin_arm_rsr64("cntvct_el0");
+		return now;
+	}
+
+	return pg_get_ticks_system();
+}
+
+static pg_attribute_always_inline instr_time
+pg_get_ticks_fast(void)
+{
+	if (likely(timing_tsc_enabled))
+	{
+		instr_time	now;
+
+		now.ticks = __builtin_arm_rsr64("cntvct_el0");
+		return now;
+	}
+
+	return pg_get_ticks_system();
+}
+
+#endif							/* defined(__x86_64__) || defined(_M_X64) */
+
+#else							/* !PG_INSTR_TSC_CLOCK */
 
 static pg_attribute_always_inline instr_time
 pg_get_ticks(void)

--- a/src/port/meson.build
+++ b/src/port/meson.build
@@ -7,6 +7,7 @@ pgport_sources = [
   'noblock.c',
   'path.c',
   'pg_bitutils.c',
+  'pg_cpu_arm.c',
   'pg_cpu_x86.c',
   'pg_getopt_ctx.c',
   'pg_localeconv_r.c',

--- a/src/port/pg_cpu_arm.c
+++ b/src/port/pg_cpu_arm.c
@@ -1,0 +1,45 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_cpu_arm.c
+ *	  Runtime CPU feature detection for AArch64
+ *
+ * Portions Copyright (c) 1996-2026, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  src/port/pg_cpu_arm.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "c.h"
+
+#if defined(__aarch64__) && !defined(_MSC_VER)
+
+#include "port/pg_cpu.h"
+
+/*
+ * Return the frequency of the ARM generic timer (CNTVCT_EL0) in kHz.
+ *
+ * The CNTFRQ_EL0 system register is architecturally guaranteed to be readable
+ * from EL0 (userspace) and holds the timer frequency in Hz. The firmware sets
+ * this at boot and it does not change.
+ *
+ * Returns 0 if the frequency is not available (should not happen on conforming
+ * implementations).
+ */
+uint32
+aarch64_cntvct_frequency_khz(void)
+{
+	uint64		freq;
+
+	freq = __builtin_arm_rsr64("cntfrq_el0");
+
+	if (freq == 0)
+		return 0;
+
+	return (uint32) (freq / 1000);
+}
+
+#endif							/* defined(__aarch64__) */


### PR DESCRIPTION
## TODO

* [ ] Confirm how M3 hardware behaves on Linux (if the GitHub issue referenced below is to be believed, the difference between cores is a macOS-ism, not a hardware issue)

## Test systems

* AWS Graviton
* [Google C4A](https://cloud.google.com/blog/products/compute/try-c4a-the-first-google-axion-processor)

## Resources

* https://developer.arm.com/documentation/102379/0104/What-is-the-Generic-Timer-
* https://tc.gts3.org/cs3210/2020/spring/r/aarch64-generic-timer.pdf
* https://wiki.osdev.org/ARMv7_Generic_Timers
* https://developer.arm.com/documentation/ka005977/latest/ (this talks about the 1 GHz frequency requirement on  Armv8.6 and higher)
* https://events19.linuxfoundation.org/wp-content/uploads/2017/12/Christopher-Dall_Arm-Timers-and-Fire.pdf (good explanation of the differences between EL2 - EL0 and how timers are handled in virtualized situations)
* https://github.com/utmapp/UTM/issues/6942#issuecomment-2568174256 (also referenced below, talks about the macOS scaling of the freuqency)
* https://developer.apple.com/documentation/macos-release-notes/macos-15-release-notes
* https://github.com/golang/go/issues/67937
* https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html (could use it to run through different CPUs on Linux and confirm the frequency matches)
* https://github.com/redis/redis/pull/14676 (change making use of CNTVCT_EL0 for Redis by default - note they don't do any special handling for macOS)
* https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1713821 / https://patchwork.ozlabs.org/project/ubuntu-kernel/patch/20170830174128.32541-3-dann.frazier@canonical.com/ / https://github.com/AsahiLinux/linux/blob/asahi/drivers/clocksource/arm_arch_timer.c#L479 (the Kernel traps CNTVCT in certain cases with broken hardware - do we care about that / can we detect that?)
* https://leo3418.github.io/asahi-wiki-build/perf-on-m1-systems/ (description of big.LITTLE handling in Asahi Linux, though this is about perf counters, not timer)
* https://asahilinux.org/docs/hw/cpu/smp/ (can this information help us detect E+P/big.LITTLE architectures?)
* https://www.computerenhance.com/p/how-does-queryperformancecounter/comment/100811972
* https://www.computerenhance.com/p/how-does-queryperformancecounter/comment/17563923

Noteworthy:

> On Apple Silicon based devices with M3 or later, and A16 Bionic or later, the values returned by reading the CNTFRQ_EL0 and CNTVCT_EL0 registers have been updated to 1 GHz, instead of the prior value of 24 MHz. It is still recommended for apps to use libsystem APIs like mach_absolute_time() for timekeeping. Your app will not be impacted by this change if it uses Apple’s timekeeping APIs. For compatibility purposes, this change will only be visible when using the SDK associated with this release or later. On macOS, applications running inside a Virtualization.framework VM will continue to receive the legacy behavior. (84639494)
https://developer.apple.com/documentation/macos-release-notes/macos-15-release-notes

> On MacOS, when applications are built with a newer SDK (15.2 SDK I think?) then Apple's kernel when starting a process will program their AGTCNTRDIR_EL1 register, which scales the values returned by CNTFRQ_EL0 and CNTVCT_EL0 to operate at 1Ghz instead. The clock is still actually running at 24Mhz, but it increments larger amounts. So its granularity instead of being 1, is ~41.6.
>
> This is required to be done according to ARMv8.6/v9.1 spec otherwise it isn't compliant hardware. From the ARM Architecture reference manual, From Armv8.6 the counter operates at a higher fixed frequency of 1GHz.
https://github.com/utmapp/UTM/issues/6942#issuecomment-2568174256

---

The lower frequency on old ARM (and current Apple Silicon) is likely a general problem, and can already be observed by running `pg_test_timing` on ARM machines today, and seeing the timing durations not move:

```
Testing timing overhead for 3 seconds.

System clock source: clock_gettime (CLOCK_MONOTONIC_RAW)
Average loop time including overhead: 16.35 ns
Histogram of timing durations:
   <= ns   % of total  running %      count
       0      61.0142    61.0142  111945941
       1       0.0000    61.0142          0
       3       0.0000    61.0142          0
       7       0.0000    61.0142          0
      15       0.0000    61.0142          0
      31       0.0000    61.0142          0
      63      38.9193    99.9335   71407352
     127       0.0569    99.9905     104482
     255       0.0085    99.9990      15603
     511       0.0001    99.9991        221
    1023       0.0001    99.9992        127
    2047       0.0002    99.9993        299
    4095       0.0001    99.9995        215
    8191       0.0003    99.9998        561
   16383       0.0001    99.9999        271
   32767       0.0001   100.0000         97
   65535       0.0000   100.0000         51
  131071       0.0000   100.0000          4

Observed timing durations up to 99.9900%:
      ns   % of total  running %      count
       0      61.0142    61.0142  111945941
      41      12.9731    73.9873   23802478
      42      25.9462    99.9335   47604874
      83       0.0296    99.9631      54312
      84       0.0148    99.9779      27130
     125       0.0126    99.9905      23040
...
   77333       0.0000   100.0000          1
```